### PR TITLE
fix for b2/79184992

### DIFF
--- a/teapots/choreographer-30fps/src/main/cpp/CMakeLists.txt
+++ b/teapots/choreographer-30fps/src/main/cpp/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 3.4.1)
 project(ChoreographerNativeActivity LANGUAGES C CXX)
 
 # set up common compile options
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -fno-exceptions -fno-rtti")
+set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Werror -fno-exceptions -fno-rtti")
 
 # build the ndk-helper library into a common directory
 # visible to all 3 projects avoiding duplicate builds.

--- a/teapots/classic-teapot/src/main/cpp/CMakeLists.txt
+++ b/teapots/classic-teapot/src/main/cpp/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 3.4.1)
 project(TeapotNativeActivity LANGUAGES C CXX)
 
 # set up common compile options
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -fno-exceptions -fno-rtti")
+set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Werror -fno-exceptions -fno-rtti")
 
 # build the ndk-helper library into a common directory
 # visible to all 3 projects avoiding duplicate builds.

--- a/teapots/common/ndk_helper/sensorManager.cpp
+++ b/teapots/common/ndk_helper/sensorManager.cpp
@@ -44,36 +44,6 @@ void SensorManager::Init(android_app *app) {
       sensorManager_, app->looper, LOOPER_ID_USER, NULL, NULL);
 }
 
-void SensorManager::Process(const int32_t id) {
-  // If a sensor has data, process it now.
-  if (id == LOOPER_ID_USER) {
-    if (accelerometerSensor_ != NULL) {
-      ASensorEvent event;
-      while (ASensorEventQueue_getEvents(sensorEventQueue_, &event, 1) > 0) {
-        float maginitude = event.acceleration.x * event.acceleration.x +
-                           event.acceleration.y * event.acceleration.y;
-        if (maginitude * 4 >= event.acceleration.z * event.acceleration.z) {
-          int32_t orientation = ORIENTATION_REVERSE_LANDSCAPE;
-          float angle = atan2f(-event.acceleration.y, event.acceleration.x);
-          if (angle <= -M_PI_2 - M_PI_4) {
-            orientation = ORIENTATION_REVERSE_LANDSCAPE;
-          } else if (angle <= -M_PI_4) {
-            orientation = ORIENTATION_PORTRAIT;
-          } else if (angle <= M_PI_4) {
-            orientation = ORIENTATION_LANDSCAPE;
-          } else if (angle <= M_PI_2 + M_PI_4) {
-            orientation = ORIENTATION_REVERSE_PORTRAIT;
-          }
-
-          //					LOGI( "orientation %f %d", angle,
-          //orientation);
-          (void)orientation;
-        }
-      }
-    }
-  }
-}
-
 void SensorManager::Resume() {
   // When the app gains focus, start monitoring the accelerometer.
   if (accelerometerSensor_ != NULL) {

--- a/teapots/common/ndk_helper/sensorManager.h
+++ b/teapots/common/ndk_helper/sensorManager.h
@@ -50,7 +50,6 @@ class SensorManager {
   SensorManager();
   ~SensorManager();
   void Init(android_app *state);
-  void Process(const int32_t id);
   void Suspend();
   void Resume();
 };

--- a/teapots/more-teapots/src/main/cpp/CMakeLists.txt
+++ b/teapots/more-teapots/src/main/cpp/CMakeLists.txt
@@ -18,7 +18,7 @@ cmake_minimum_required(VERSION 3.4.1)
 project(MoreTeapotsNativeActivity LANGUAGES C CXX)
 
 # set up common compile options
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -fno-exceptions -fno-rtti")
+set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Werror -fno-exceptions -fno-rtti")
 
 # build the ndk-helper library into a common directory
 # visible to all 3 projects avoiding duplicate builds.


### PR DESCRIPTION
1. remove  ndk_helper::SensorManager::Process()
2.  add -Wno-attributes for gcc case
When using gcc, 2 warning coming up. Surprisingly that clang does not detect the first one above.  The second one is related to [known issue](https://stackoverflow.com/questions/39830538/ndk-r13-fexceptions-wall-warning-conflicts-with-previous-declaration).

@hak @DanAlbert please carefully review this PR, thanks!