### PR TITLE
clean-up: 

### DIFF
--- a/other-builds/ndkbuild/gles3jni/app/AndroidManifest-18.xml
+++ b/other-builds/ndkbuild/gles3jni/app/AndroidManifest-18.xml
@@ -29,5 +29,4 @@
         </activity>
     </application>
     <uses-feature android:glEsVersion="0x00030000"/>
-    <uses-sdk android:minSdkVersion="18"/>
 </manifest>

--- a/other-builds/ndkbuild/gles3jni/app/AndroidManifest.xml
+++ b/other-builds/ndkbuild/gles3jni/app/AndroidManifest.xml
@@ -29,5 +29,4 @@
         </activity>
     </application>
     <uses-feature android:glEsVersion="0x00030000"/>
-    <uses-sdk android:minSdkVersion="18"/>
 </manifest>


### PR DESCRIPTION
Sample: otherbuild\gl3init -- removing redundant minSdk requirment in AndroidManifest.xml

Tested: Pixel3 XL GSI image