### PR TITLE
Remove invalid call to glHint()

### DIFF
--- a/native-activity/app/src/main/cpp/main.cpp
+++ b/native-activity/app/src/main/cpp/main.cpp
@@ -146,7 +146,6 @@ static int engine_init_display(struct engine* engine) {
         LOGI("OpenGL Info: %s", info);
     }
     // Initialize GL state.
-    glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_FASTEST);
     glEnable(GL_CULL_FACE);
     glShadeModel(GL_SMOOTH);
     glDisable(GL_DEPTH_TEST);


### PR DESCRIPTION
Parameter GL_PERSPECTIVE_CORRECTION_HINT is not among the valid ones
with respect to the GLES 3 specification, see:
https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glHint.xhtml

fix #637 