### PR TITLE
fix internal bug b/142666190

### DIFF
--- a/other-builds/ndkbuild/bitmap-plasma/app/Android.mk
+++ b/other-builds/ndkbuild/bitmap-plasma/app/Android.mk
@@ -13,7 +13,14 @@
 # limitations under the License.
 #
 
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
 
 LOCAL_PATH := $(call my-dir)
 PROJECT_DIR :=bitmap-plasma

--- a/other-builds/ndkbuild/gles3jni/app/Android.mk
+++ b/other-builds/ndkbuild/gles3jni/app/Android.mk
@@ -14,7 +14,14 @@
 LOCAL_PATH:= $(call my-dir)
 include $(CLEAR_VARS)
 
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
 
 JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../gles3jni/app/src/main/cpp)
 

--- a/other-builds/ndkbuild/hello-gl2/app/Android.mk
+++ b/other-builds/ndkbuild/hello-gl2/app/Android.mk
@@ -13,7 +13,14 @@
 # limitations under the License.
 #
 
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
 
 LOCAL_PATH:= $(call my-dir)
 

--- a/other-builds/ndkbuild/hello-jni/app/Android.mk
+++ b/other-builds/ndkbuild/hello-jni/app/Android.mk
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
 
 LOCAL_PATH := $(call my-dir)
 JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../hello-jni/app/src/main/cpp)

--- a/other-builds/ndkbuild/hello-libs/app/Android.mk
+++ b/other-builds/ndkbuild/hello-libs/app/Android.mk
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
 
 LOCAL_PATH := $(call my-dir)
 JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../hello-libs/app/src/main/cpp)

--- a/other-builds/ndkbuild/hello-neon/app/Android.mk
+++ b/other-builds/ndkbuild/hello-neon/app/Android.mk
@@ -1,4 +1,12 @@
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
+
 
 LOCAL_PATH := $(call my-dir)
 JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../hello-neon/app/src/main/cpp)

--- a/other-builds/ndkbuild/native-activity/app/Android.mk
+++ b/other-builds/ndkbuild/native-activity/app/Android.mk
@@ -13,7 +13,15 @@
 # limitations under the License.
 #
 
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
+
 
 LOCAL_PATH := $(call my-dir)
 JNI_SRC_PATH := $(call abspath_wa,$(LOCAL_PATH)/../../../../native-activity/app/src/main/cpp)

--- a/other-builds/ndkbuild/native-audio/app/Android.mk
+++ b/other-builds/ndkbuild/native-audio/app/Android.mk
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
+
 
 LOCAL_PATH := $(call my-dir)
 JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../native-audio/app/src/main/cpp)

--- a/other-builds/ndkbuild/native-codec/app/Android.mk
+++ b/other-builds/ndkbuild/native-codec/app/Android.mk
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
+
 
 LOCAL_PATH := $(call my-dir)
 JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../native-codec/app/src/main/cpp)

--- a/other-builds/ndkbuild/native-media/app/Android.mk
+++ b/other-builds/ndkbuild/native-media/app/Android.mk
@@ -12,7 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
+
 
 LOCAL_PATH := $(call my-dir)
 

--- a/other-builds/ndkbuild/native-plasma/app/Android.mk
+++ b/other-builds/ndkbuild/native-plasma/app/Android.mk
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
+
 
 LOCAL_PATH := $(call my-dir)
 JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../native-plasma/app/src/main/cpp)

--- a/other-builds/ndkbuild/nn_sample/app/Android.mk
+++ b/other-builds/ndkbuild/nn_sample/app/Android.mk
@@ -1,4 +1,12 @@
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
+
 
 LOCAL_PATH := $(call my-dir)
 

--- a/other-builds/ndkbuild/san-angeles/app/Android.mk
+++ b/other-builds/ndkbuild/san-angeles/app/Android.mk
@@ -1,4 +1,12 @@
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
+
 
 LOCAL_PATH := $(call my-dir)
 JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../san-angeles/app/src/main/cpp)

--- a/other-builds/ndkbuild/teapots/classic-teapot/Android.mk
+++ b/other-builds/ndkbuild/teapots/classic-teapot/Android.mk
@@ -1,4 +1,12 @@
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
+
 
 LOCAL_PATH := $(call my-dir)
 

--- a/other-builds/ndkbuild/teapots/more-teapots/Android.mk
+++ b/other-builds/ndkbuild/teapots/more-teapots/Android.mk
@@ -1,4 +1,12 @@
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+# workaround possible long file path issue on Windows host
+NDK_VER=$(firstword $(subst ., ,$(lastword $(file < $(NDK_ROOT)/source.properties))))
+ifeq ($(filter $(NDK_VER),21 22 23 24 25),)
+  # For NDK 21 and before, need to workaround make's abspath issue
+  abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+else
+  abspath_wa = $(abspath $1)
+endif
+
 
 LOCAL_PATH := $(call my-dir)
 


### PR DESCRIPTION
NDK R21 fixed gnu make's abspath issue on Windows Host, no need to use
the workaround. After NDK R25 is released, will totally remove
abspath_wa() in Android.mk files

Will merge after NDK-R21 is formally released