### PR TITLE
Improve libraries build code

### DIFF
--- a/hello-libs/app/build.gradle
+++ b/hello-libs/app/build.gradle
@@ -38,20 +38,8 @@ android {
 
 dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
+    // uncomment out this one to generate lib binaries,
+    // and also uncommented out the one in settings.gradle
+    // after lib is generated, just comment them out again
+//    api project(':gen-libs')
 }
-
-// Workaround library native code dependency issue in gradle 3.0.0
-// refer to https://issuetracker.google.com/issues/69616088
-// Note that the followings are only needed to generate lib package
-// into $project/distribution directory, does NOT affect application module;
-// Only enable these when want to build libs (together with note
-// inside settings.gradle)
-/*
-tasks.whenTaskAdded { task ->
-    if (task.name == 'externalNativeBuildRelease') {
-        task.dependsOn ":gen-libs:externalNativeBuildRelease"
-    } else if (task.name == 'externalNativeBuildDebug') {
-        task.dependsOn ":gen-libs:externalNativeBuildDebug"
-    }
-}
-*/

--- a/hello-libs/build.gradle
+++ b/hello-libs/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.5.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/hello-libs/gen-libs/src/main/cpp/CMakeLists.txt
+++ b/hello-libs/gen-libs/src/main/cpp/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 set(lib_src_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-set(lib_build_DIR $ENV{HOME}/tmp)
+set(lib_build_DIR $ENV{HOME}/tmp/${ANDROID_ABI})
 file(MAKE_DIRECTORY ${lib_build_DIR})
 
 add_subdirectory(${lib_src_DIR}/gmath ${lib_build_DIR}/gmath)

--- a/hello-libs/gradle/wrapper/gradle-wrapper.properties
+++ b/hello-libs/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 08 15:36:19 PDT 2018
+#Sun Oct 27 00:19:39 EEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
Changes:
  1. Bring back strong dependency from "gen-libs" module in "app" module (workaround is not needed anymore)
  2. Make it possible to do repeated (incremental) build, when libraries are build as well. It might be not so interesting in the context of this sample project, but it is very helpful in real projects which build native libraries along with Java code, rather than using pre-built lib versions. This is usually the case when such library is only being developed for some particular app.

After updating to new Gradle plugin, the "wrong format" issue is reproducing with 100% probability, that's why I decided to send those patches (which help in my pet project), and that's why I included Gradle plugin update patch in this patch series.

See commit messages for details.