### PR TITLE
teapot: fix missing precision qualifier

### DIFF
--- a/teapots/textured-teapot/src/main/assets/Shaders/Cubemap.fsh
+++ b/teapots/textured-teapot/src/main/assets/Shaders/Cubemap.fsh
@@ -35,7 +35,7 @@ void main()
     mediump float specular = pow(NdotH, fPower);
 
     lowp vec4 colorSpecular = vec4( vMaterialSpecular.xyz * specular, 1 );
-    vec3 texCoord = normal;
+    mediump vec3 texCoord = normal;
     texCoord.y = -normal.y;
     gl_FragColor = colorDiffuse * textureCube(samplerObj, normalize(texCoord)) +
                       vec4(vMaterialAmbient.xyz, 1.0);


### PR DESCRIPTION
Some GPU devices likes ARM Mali midgard would fail
in compiling this shader.

Qualcomm adreno seems free of this problem.

Signed-off-by: Hsia-Jun Li(Randy) <ayaka@soulik.info>