### PR TITLE
Drop bug in workaround for r21+.

### DIFF
--- a/other-builds/ndkbuild/bitmap-plasma/app/Android.mk
+++ b/other-builds/ndkbuild/bitmap-plasma/app/Android.mk
@@ -1,4 +1,5 @@
-# Lopyright (C) The Android Open Source Project
+#
+# Copyright (C) 2016 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,11 +14,12 @@
 # limitations under the License.
 #
 
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
-
 LOCAL_PATH := $(call my-dir)
-PROJECT_DIR :=bitmap-plasma
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../$(PROJECT_DIR)/app/src/main/cpp)
+
+include $(LOCAL_PATH)/../../common.mk
+
+PROJECT_DIR := bitmap-plasma
+JNI_SRC_PATH := $(SAMPLES_ROOT)/$(PROJECT_DIR)/app/src/main/cpp
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/common.mk
+++ b/other-builds/ndkbuild/common.mk
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2019 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+COMMON_PATH := $(call my-dir)
+
+# Workaround a bug in abspath on Windows that existed in older versions of make
+# (paths with drive letters were not handled properly in abspath). r21+ has a
+# newer version of make that doesn't have this bug.
+ifeq ($(call ndk-major-at-least,21),true)
+    shorten_path = $(abspath $1)
+else
+    # Strip the drive letter, call abspath, prepend the drive letter.
+    shorten_path = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+endif
+
+SAMPLES_ROOT := $(call shorten_path,$(COMMON_PATH)/../..)

--- a/other-builds/ndkbuild/gles3jni/app/Android.mk
+++ b/other-builds/ndkbuild/gles3jni/app/Android.mk
@@ -1,4 +1,5 @@
-# Copyright The Android Open Source Project
+#
+# Copyright (C) 2016 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,12 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-LOCAL_PATH:= $(call my-dir)
+#
+
+LOCAL_PATH := $(call my-dir)
+
+include $(LOCAL_PATH)/../../common.mk
+
 include $(CLEAR_VARS)
 
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
-
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../gles3jni/app/src/main/cpp)
+JNI_SRC_PATH := $(SAMPLES_ROOT)/gles3jni/app/src/main/cpp
 
 LOCAL_MODULE    := libgles3jni
 LOCAL_CPPFLAGS    := -Werror -std=c++11 -fno-rtti -fno-exceptions -Wall

--- a/other-builds/ndkbuild/hello-gl2/app/Android.mk
+++ b/other-builds/ndkbuild/hello-gl2/app/Android.mk
@@ -1,4 +1,5 @@
-# Copyright (C) The Android Open Source Project
+#
+# Copyright (C) 2016 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,11 +14,11 @@
 # limitations under the License.
 #
 
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+LOCAL_PATH := $(call my-dir)
 
-LOCAL_PATH:= $(call my-dir)
+include $(LOCAL_PATH)/../../common.mk
 
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../hello-gl2/app/src/main/cpp)
+JNI_SRC_PATH := $(SAMPLES_ROOT)/hello-gl2/app/src/main/cpp
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/hello-jni/app/Android.mk
+++ b/other-builds/ndkbuild/hello-jni/app/Android.mk
@@ -1,4 +1,5 @@
-# Copyright (C) The Android Open Source Project
+#
+# Copyright (C) 2016 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
 
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../hello-jni/app/src/main/cpp)
+
+include $(LOCAL_PATH)/../../common.mk
+
+JNI_SRC_PATH := $(SAMPLES_ROOT)/hello-jni/app/src/main/cpp
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/hello-libs/app/Android.mk
+++ b/other-builds/ndkbuild/hello-libs/app/Android.mk
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
 
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../hello-libs/app/src/main/cpp)
-include $(CLEAR_VARS)
 
-# config distributed lib path
-EXT_LIB_ROOT := $(call abspath_wa, $(LOCAL_PATH)/../../../../hello-libs/distribution)
+include $(LOCAL_PATH)/../../common.mk
+
+JNI_SRC_PATH := $(SAMPLES_ROOT)/hello-libs/app/src/main/cpp
+EXT_LIB_ROOT := $(SAMPLES_ROOT)/hello-libs/distribution
+
+include $(CLEAR_VARS)
 
 # import 2 libs: remember to generate them SEPARATELY in terminal/command line first!
 LOCAL_MODULE := local_gmath

--- a/other-builds/ndkbuild/hello-neon/app/Android.mk
+++ b/other-builds/ndkbuild/hello-neon/app/Android.mk
@@ -1,7 +1,20 @@
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+#
+# Copyright (C) 2016 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../hello-neon/app/src/main/cpp)
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/native-activity/app/Android.mk
+++ b/other-builds/ndkbuild/native-activity/app/Android.mk
@@ -13,10 +13,11 @@
 # limitations under the License.
 #
 
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
-
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(call abspath_wa,$(LOCAL_PATH)/../../../../native-activity/app/src/main/cpp)
+
+include $(LOCAL_PATH)/../../common.mk
+
+JNI_SRC_PATH := $(SAMPLES_ROOT)/native-activity/app/src/main/cpp
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/native-audio/app/Android.mk
+++ b/other-builds/ndkbuild/native-audio/app/Android.mk
@@ -1,4 +1,5 @@
-# Copyright (C) The Android Open Source Project
+#
+# Copyright (C) 2016 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
 
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../native-audio/app/src/main/cpp)
+
+include $(LOCAL_PATH)/../../common.mk
+
+JNI_SRC_PATH := $(SAMPLES_ROOT)/native-audio/app/src/main/cpp
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/native-codec/app/Android.mk
+++ b/other-builds/ndkbuild/native-codec/app/Android.mk
@@ -1,4 +1,5 @@
-# Copyright (C) The Android Open Source Project
+#
+# Copyright (C) 2016 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
 
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../native-codec/app/src/main/cpp)
+
+include $(LOCAL_PATH)/../../common.mk
+
+JNI_SRC_PATH := $(SAMPLES_ROOT)/native-codec/app/src/main/cpp
+
 include $(CLEAR_VARS)
 
 LOCAL_MODULE    := native-codec-jni

--- a/other-builds/ndkbuild/native-media/app/Android.mk
+++ b/other-builds/ndkbuild/native-media/app/Android.mk
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
 
 LOCAL_PATH := $(call my-dir)
 
+include $(LOCAL_PATH)/../../common.mk
+
 include $(CLEAR_VARS)
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../native-media/app/src/main/cpp)
+JNI_SRC_PATH := $(SAMPLES_ROOT)/native-media/app/src/main/cpp
 
 LOCAL_MODULE    := native-media-jni
 LOCAL_SRC_FILES := $(JNI_SRC_PATH)/native-media-jni.c \

--- a/other-builds/ndkbuild/native-plasma/app/Android.mk
+++ b/other-builds/ndkbuild/native-plasma/app/Android.mk
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
 
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../native-plasma/app/src/main/cpp)
+
+include $(LOCAL_PATH)/../../common.mk
+
+JNI_SRC_PATH := $(SAMPLES_ROOT)/native-plasma/app/src/main/cpp
+
 include $(CLEAR_VARS)
 
 LOCAL_MODULE    := native-plasma

--- a/other-builds/ndkbuild/nn_sample/app/Android.mk
+++ b/other-builds/ndkbuild/nn_sample/app/Android.mk
@@ -1,8 +1,24 @@
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+#
+# Copyright (C) 2018 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 LOCAL_PATH := $(call my-dir)
 
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../nn_sample/app/src/main/cpp)
+include $(LOCAL_PATH)/../../common.mk
+
+JNI_SRC_PATH := $(SAMPLES_ROOT)/nn_sample/app/src/main/cpp
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/san-angeles/app/Android.mk
+++ b/other-builds/ndkbuild/san-angeles/app/Android.mk
@@ -1,7 +1,24 @@
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+#
+# Copyright (C) 2016 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 LOCAL_PATH := $(call my-dir)
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../san-angeles/app/src/main/cpp)
+
+include $(LOCAL_PATH)/../../common.mk
+
+JNI_SRC_PATH := $(SAMPLES_ROOT)/san-angeles/app/src/main/cpp
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/teapots/classic-teapot/Android.mk
+++ b/other-builds/ndkbuild/teapots/classic-teapot/Android.mk
@@ -1,9 +1,25 @@
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+#
+# Copyright (C) 2016 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 LOCAL_PATH := $(call my-dir)
 
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../teapots/classic-teapot/src/main/cpp)
-NDK_HELPER_SRC :=$(call abspath_wa, $(LOCAL_PATH)/../../../../teapots/common/ndk_helper)
+include $(LOCAL_PATH)/../../common.mk
+
+JNI_SRC_PATH := $(SAMPLES_ROOT)/teapots/classic-teapot/src/main/cpp
+NDK_HELPER_SRC :=$(SAMPLES_ROOT)/teapots/common/ndk_helper
 
 include $(CLEAR_VARS)
 

--- a/other-builds/ndkbuild/teapots/more-teapots/Android.mk
+++ b/other-builds/ndkbuild/teapots/more-teapots/Android.mk
@@ -1,9 +1,25 @@
-abspath_wa = $(join $(filter %:,$(subst :,: ,$1)),$(abspath $(filter-out %:,$(subst :,: ,$1))))
+#
+# Copyright (C) 2016 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 LOCAL_PATH := $(call my-dir)
 
-JNI_SRC_PATH := $(call abspath_wa, $(LOCAL_PATH)/../../../../teapots/more-teapots/src/main/cpp)
-NDK_HELPER_SRC := $(call abspath_wa, $(LOCAL_PATH)/../../../../teapots/common/ndk_helper)
+include $(LOCAL_PATH)/../../common.mk
+
+JNI_SRC_PATH := $(SAMPLES_ROOT)/teapots/more-teapots/src/main/cpp
+NDK_HELPER_SRC := $(SAMPLES_ROOT)/teapots/common/ndk_helper
 
 include $(CLEAR_VARS)
 


### PR DESCRIPTION
This workaround for a bug in abspath used to workaround path length
issues in Windows is not needed in r21+ because the abspath bug was
fixed. Unfortunately the bug being fixed means that the workaround now
introduces a bug when forming the path. Only use the workaround for
pre-r21 NDKs.

Bug: http://b/142666190