### PR TITLE
Remove obsolete jniLibs configuration.

### DIFF
--- a/hello-libs/README.md
+++ b/hello-libs/README.md
@@ -23,9 +23,6 @@ When importing libraries into your app, include the following in your app's `CMa
 *    configure each library binary location(using `set_target_properties`)
 *    configure each library headers location (using `target_include_directories`)
 
-For shared libraries, notify gradle to pack them into APK. One simple way is to include the shared lib directory into application's jniLibs directory:
-*    jniLibs.srcDirs = ['../distribution/gperf/lib']
-
 Pre-requisites
 --------------
 - Android Studio 3.0.0 with [NDK](https://developer.android.com/ndk/) bundle.

--- a/hello-libs/app/build.gradle
+++ b/hello-libs/app/build.gradle
@@ -22,12 +22,6 @@ android {
                           'proguard-rules.pro'
         }
     }
-    sourceSets {
-        main {
-            // let gradle pack the shared library into apk
-            jniLibs.srcDirs = ['../distribution/gperf/lib']
-        }
-    }
     externalNativeBuild {
         cmake {
             version '3.10.2'

--- a/hello-libs/app/src/main/cpp/CMakeLists.txt
+++ b/hello-libs/app/src/main/cpp/CMakeLists.txt
@@ -24,8 +24,8 @@ add_library(lib_gmath STATIC IMPORTED)
 set_target_properties(lib_gmath PROPERTIES IMPORTED_LOCATION
     ${distribution_DIR}/gmath/lib/${ANDROID_ABI}/libgmath.a)
 
-# shared lib will also be tucked into APK and sent to target
-# refer to app/build.gradle, jniLibs section for that purpose.
+# Since this library is a dependency of hello-libs, it is automatically packed
+# into the APK.
 # ${ANDROID_ABI} is handy for our purpose here. Probably this ${ANDROID_ABI} is
 # the most valuable thing of this sample, the rest are pretty much normal cmake
 add_library(lib_gperf SHARED IMPORTED)

--- a/hello-libs/build.gradle
+++ b/hello-libs/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:4.0.0-rc01'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/hello-libs/gradle/wrapper/gradle-wrapper.properties
+++ b/hello-libs/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
Configuring jniLibs for explicit dependencies is no longer necessary
as of 4.0. In fact, this will result in a build failure since it is
being copied twice:

    * What went wrong:
    Execution failed for task ':app:mergeDebugNativeLibs'.
    > A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
       > More than one file was found with OS independent path 'lib/x86/libgperf.so'

Also see http://b/154909008