### PR TITLE
Add ndkVersion

### DIFF
--- a/audio-echo/app/build.gradle
+++ b/audio-echo/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.google.sample.echo'

--- a/audio-echo/app/build.gradle
+++ b/audio-echo/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.google.sample.echo'

--- a/bitmap-plasma/app/build.gradle
+++ b/bitmap-plasma/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig.with {
         applicationId 'com.example.plasma'

--- a/bitmap-plasma/app/build.gradle
+++ b/bitmap-plasma/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig.with {
         applicationId 'com.example.plasma'

--- a/camera/basic/build.gradle
+++ b/camera/basic/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.sample.camera.basic'

--- a/camera/basic/build.gradle
+++ b/camera/basic/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.sample.camera.basic'

--- a/camera/texture-view/build.gradle
+++ b/camera/texture-view/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId "com.sample.textureview"

--- a/camera/texture-view/build.gradle
+++ b/camera/texture-view/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId "com.sample.textureview"

--- a/display-p3/image-view/build.gradle
+++ b/display-p3/image-view/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId = 'com.example.widecolor'

--- a/display-p3/image-view/build.gradle
+++ b/display-p3/image-view/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId = 'com.example.widecolor'

--- a/endless-tunnel/app/build.gradle
+++ b/endless-tunnel/app/build.gradle
@@ -18,6 +18,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.google.sample.tunnel'

--- a/endless-tunnel/app/build.gradle
+++ b/endless-tunnel/app/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.google.sample.tunnel'

--- a/gles3jni/app/build.gradle
+++ b/gles3jni/app/build.gradle
@@ -6,7 +6,7 @@ def platformVersion = 24      // openGLES 3.2 min api level
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.android.gles3jni'

--- a/gles3jni/app/build.gradle
+++ b/gles3jni/app/build.gradle
@@ -6,6 +6,7 @@ def platformVersion = 24      // openGLES 3.2 min api level
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.android.gles3jni'

--- a/hello-cdep/app/build.gradle
+++ b/hello-cdep/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId = 'com.example.hellolibs'

--- a/hello-cdep/app/build.gradle
+++ b/hello-cdep/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId = 'com.example.hellolibs'

--- a/hello-gl2/app/build.gradle
+++ b/hello-gl2/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
     
     defaultConfig {
         applicationId 'com.android.gl2jni'

--- a/hello-gl2/app/build.gradle
+++ b/hello-gl2/app/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
+    
     defaultConfig {
         applicationId 'com.android.gl2jni'
         minSdkVersion 14

--- a/hello-jni/app/build.gradle
+++ b/hello-jni/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.example.hellojni'

--- a/hello-jni/app/build.gradle
+++ b/hello-jni/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.example.hellojni'

--- a/hello-jniCallback/app/build.gradle
+++ b/hello-jniCallback/app/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
+    
     defaultConfig {
         applicationId 'com.example.hellojnicallback'
         minSdkVersion 21

--- a/hello-jniCallback/app/build.gradle
+++ b/hello-jniCallback/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
     
     defaultConfig {
         applicationId 'com.example.hellojnicallback'

--- a/hello-libs/app/build.gradle
+++ b/hello-libs/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId = 'com.example.hellolibs'

--- a/hello-libs/app/build.gradle
+++ b/hello-libs/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId = 'com.example.hellolibs'

--- a/hello-libs/gen-libs/build.gradle
+++ b/hello-libs/gen-libs/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         minSdkVersion 14

--- a/hello-libs/gen-libs/build.gradle
+++ b/hello-libs/gen-libs/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         minSdkVersion 14

--- a/hello-libs/gradle/wrapper/gradle-wrapper.properties
+++ b/hello-libs/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/hello-neon/app/build.gradle
+++ b/hello-neon/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
     
     defaultConfig {
         applicationId "com.example.helloneon"

--- a/hello-neon/app/build.gradle
+++ b/hello-neon/app/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
+    
     defaultConfig {
         applicationId "com.example.helloneon"
         minSdkVersion 14

--- a/hello-oboe/app/build.gradle
+++ b/hello-oboe/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
     
     defaultConfig {
         applicationId "com.google.example.hellooboe"

--- a/hello-oboe/app/build.gradle
+++ b/hello-oboe/app/build.gradle
@@ -6,6 +6,8 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
+    
     defaultConfig {
         applicationId "com.google.example.hellooboe"
         minSdkVersion 16

--- a/kotlin-app/hello-jni-kotlinApp/app/build.gradle
+++ b/kotlin-app/hello-jni-kotlinApp/app/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
     
     defaultConfig {
         applicationId 'com.example.kotlinjni'

--- a/kotlin-app/hello-jni-kotlinApp/app/build.gradle
+++ b/kotlin-app/hello-jni-kotlinApp/app/build.gradle
@@ -20,6 +20,8 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
+    
     defaultConfig {
         applicationId 'com.example.kotlinjni'
         minSdkVersion 23

--- a/kotlin-app/nn-sample-kotlinApp/app/build.gradle
+++ b/kotlin-app/nn-sample-kotlinApp/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
     
     defaultConfig {
         applicationId "com.example.android.nnapidemo"

--- a/kotlin-app/nn-sample-kotlinApp/app/build.gradle
+++ b/kotlin-app/nn-sample-kotlinApp/app/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
+    
     defaultConfig {
         applicationId "com.example.android.nnapidemo"
         minSdkVersion 27

--- a/native-activity/app/build.gradle
+++ b/native-activity/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId = 'com.example.native_activity'

--- a/native-activity/app/build.gradle
+++ b/native-activity/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId = 'com.example.native_activity'

--- a/native-audio/app/build.gradle
+++ b/native-audio/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
      compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
      defaultConfig {
         applicationId 'com.example.nativeaudio'

--- a/native-audio/app/build.gradle
+++ b/native-audio/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
      compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
      defaultConfig {
         applicationId 'com.example.nativeaudio'

--- a/native-codec/app/build.gradle
+++ b/native-codec/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.example.nativecodec'

--- a/native-codec/app/build.gradle
+++ b/native-codec/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.example.nativecodec'

--- a/native-media/app/build.gradle
+++ b/native-media/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.example.nativemedia'

--- a/native-media/app/build.gradle
+++ b/native-media/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.example.nativemedia'

--- a/native-midi/app/build.gradle
+++ b/native-midi/app/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
+    
     defaultConfig {
         applicationId "com.example.nativemidi"
         minSdkVersion 29

--- a/native-midi/app/build.gradle
+++ b/native-midi/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
     
     defaultConfig {
         applicationId "com.example.nativemidi"

--- a/native-plasma/app/build.gradle
+++ b/native-plasma/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.example.native_plasma'

--- a/native-plasma/app/build.gradle
+++ b/native-plasma/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.example.native_plasma'

--- a/nn-samples/basic/build.gradle
+++ b/nn-samples/basic/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 29
     buildToolsVersion '29.0.3'
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId "com.example.android.basic"

--- a/other-builds/ndkbuild/bitmap-plasma/app/build.gradle
+++ b/other-builds/ndkbuild/bitmap-plasma/app/build.gradle
@@ -6,6 +6,7 @@ def REMOTE_PROJ_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId "com.example.plasma"

--- a/other-builds/ndkbuild/bitmap-plasma/app/build.gradle
+++ b/other-builds/ndkbuild/bitmap-plasma/app/build.gradle
@@ -6,7 +6,7 @@ def REMOTE_PROJ_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId "com.example.plasma"

--- a/other-builds/ndkbuild/gles3jni/app/build.gradle
+++ b/other-builds/ndkbuild/gles3jni/app/build.gradle
@@ -13,6 +13,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.android.gles3jni'

--- a/other-builds/ndkbuild/gles3jni/app/build.gradle
+++ b/other-builds/ndkbuild/gles3jni/app/build.gradle
@@ -13,7 +13,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.android.gles3jni'

--- a/other-builds/ndkbuild/hello-gl2/app/build.gradle
+++ b/other-builds/ndkbuild/hello-gl2/app/build.gradle
@@ -5,6 +5,8 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
+    
     defaultConfig {
         applicationId 'com.android.gl2jni'
         minSdkVersion 14

--- a/other-builds/ndkbuild/hello-gl2/app/build.gradle
+++ b/other-builds/ndkbuild/hello-gl2/app/build.gradle
@@ -5,7 +5,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
     
     defaultConfig {
         applicationId 'com.android.gl2jni'

--- a/other-builds/ndkbuild/hello-jni/app/build.gradle
+++ b/other-builds/ndkbuild/hello-jni/app/build.gradle
@@ -5,7 +5,7 @@ def REMOTE_PROJ_ROOT = '../../../../' + rootProject.getName() + '/' +
                         project.getName() + '/src/main'
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId "com.example.hellojni"

--- a/other-builds/ndkbuild/hello-jni/app/build.gradle
+++ b/other-builds/ndkbuild/hello-jni/app/build.gradle
@@ -5,6 +5,7 @@ def REMOTE_PROJ_ROOT = '../../../../' + rootProject.getName() + '/' +
                         project.getName() + '/src/main'
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId "com.example.hellojni"

--- a/other-builds/ndkbuild/hello-libs/app/build.gradle
+++ b/other-builds/ndkbuild/hello-libs/app/build.gradle
@@ -10,7 +10,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId = 'com.example.hellolibs'

--- a/other-builds/ndkbuild/hello-libs/app/build.gradle
+++ b/other-builds/ndkbuild/hello-libs/app/build.gradle
@@ -10,6 +10,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId = 'com.example.hellolibs'

--- a/other-builds/ndkbuild/hello-neon/app/build.gradle
+++ b/other-builds/ndkbuild/hello-neon/app/build.gradle
@@ -5,7 +5,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
     
     defaultConfig {
         applicationId "com.example.helloneon"

--- a/other-builds/ndkbuild/hello-neon/app/build.gradle
+++ b/other-builds/ndkbuild/hello-neon/app/build.gradle
@@ -5,6 +5,8 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
+    
     defaultConfig {
         applicationId "com.example.helloneon"
         minSdkVersion 14

--- a/other-builds/ndkbuild/native-activity/app/build.gradle
+++ b/other-builds/ndkbuild/native-activity/app/build.gradle
@@ -6,6 +6,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId = 'com.example.native_activity'

--- a/other-builds/ndkbuild/native-activity/app/build.gradle
+++ b/other-builds/ndkbuild/native-activity/app/build.gradle
@@ -6,7 +6,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId = 'com.example.native_activity'

--- a/other-builds/ndkbuild/native-audio/app/build.gradle
+++ b/other-builds/ndkbuild/native-audio/app/build.gradle
@@ -5,7 +5,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
      compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
      defaultConfig {
         applicationId 'com.example.nativeaudio'

--- a/other-builds/ndkbuild/native-audio/app/build.gradle
+++ b/other-builds/ndkbuild/native-audio/app/build.gradle
@@ -5,6 +5,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
      compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
      defaultConfig {
         applicationId 'com.example.nativeaudio'

--- a/other-builds/ndkbuild/native-codec/app/build.gradle
+++ b/other-builds/ndkbuild/native-codec/app/build.gradle
@@ -6,7 +6,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.example.nativecodec'

--- a/other-builds/ndkbuild/native-codec/app/build.gradle
+++ b/other-builds/ndkbuild/native-codec/app/build.gradle
@@ -6,6 +6,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.example.nativecodec'

--- a/other-builds/ndkbuild/native-media/app/build.gradle
+++ b/other-builds/ndkbuild/native-media/app/build.gradle
@@ -5,7 +5,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
      compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
      defaultConfig {
         applicationId 'com.example.nativemedia'

--- a/other-builds/ndkbuild/native-media/app/build.gradle
+++ b/other-builds/ndkbuild/native-media/app/build.gradle
@@ -5,6 +5,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
      compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
      defaultConfig {
         applicationId 'com.example.nativemedia'

--- a/other-builds/ndkbuild/native-plasma/app/build.gradle
+++ b/other-builds/ndkbuild/native-plasma/app/build.gradle
@@ -6,7 +6,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.example.native_plasma'

--- a/other-builds/ndkbuild/native-plasma/app/build.gradle
+++ b/other-builds/ndkbuild/native-plasma/app/build.gradle
@@ -6,6 +6,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.example.native_plasma'

--- a/other-builds/ndkbuild/nn-samples/basic/build.gradle
+++ b/other-builds/ndkbuild/nn-samples/basic/build.gradle
@@ -6,7 +6,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId "com.example.android.basic"

--- a/other-builds/ndkbuild/nn-samples/basic/build.gradle
+++ b/other-builds/ndkbuild/nn-samples/basic/build.gradle
@@ -6,6 +6,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId "com.example.android.basic"

--- a/other-builds/ndkbuild/san-angeles/app/build.gradle
+++ b/other-builds/ndkbuild/san-angeles/app/build.gradle
@@ -11,7 +11,7 @@ ext.versionCodes = ['armeabi-v7a':1, 'arm64-v8a':2, 'x86':3]
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.example.SanAngeles'

--- a/other-builds/ndkbuild/san-angeles/app/build.gradle
+++ b/other-builds/ndkbuild/san-angeles/app/build.gradle
@@ -11,6 +11,7 @@ ext.versionCodes = ['armeabi-v7a':1, 'arm64-v8a':2, 'x86':3]
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.example.SanAngeles'

--- a/other-builds/ndkbuild/teapots/classic-teapot/build.gradle
+++ b/other-builds/ndkbuild/teapots/classic-teapot/build.gradle
@@ -6,7 +6,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId "com.sample.teapot"

--- a/other-builds/ndkbuild/teapots/classic-teapot/build.gradle
+++ b/other-builds/ndkbuild/teapots/classic-teapot/build.gradle
@@ -6,6 +6,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId "com.sample.teapot"

--- a/other-builds/ndkbuild/teapots/more-teapots/build.gradle
+++ b/other-builds/ndkbuild/teapots/more-teapots/build.gradle
@@ -6,7 +6,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId "com.sample.moreteapots"

--- a/other-builds/ndkbuild/teapots/more-teapots/build.gradle
+++ b/other-builds/ndkbuild/teapots/more-teapots/build.gradle
@@ -6,6 +6,7 @@ def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId "com.sample.moreteapots"

--- a/other-builds/ndkbuild/two-libs/app/build.gradle
+++ b/other-builds/ndkbuild/two-libs/app/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId "com.example.twolibs"

--- a/other-builds/ndkbuild/two-libs/app/build.gradle
+++ b/other-builds/ndkbuild/two-libs/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId "com.example.twolibs"

--- a/prefab/curl-ssl/app/build.gradle
+++ b/prefab/curl-ssl/app/build.gradle
@@ -20,6 +20,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
     defaultConfig {
         applicationId "com.example.curlssl"
         minSdkVersion 21

--- a/prefab/curl-ssl/app/build.gradle
+++ b/prefab/curl-ssl/app/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
     defaultConfig {
         applicationId "com.example.curlssl"
         minSdkVersion 21

--- a/san-angeles/app/build.gradle
+++ b/san-angeles/app/build.gradle
@@ -7,6 +7,7 @@ ext.versionCodes = ['armeabi-v7a':1, 'arm64-v8a':2, 'mips':3, 'x86':4]
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.example.SanAngeles'

--- a/san-angeles/app/build.gradle
+++ b/san-angeles/app/build.gradle
@@ -7,7 +7,7 @@ ext.versionCodes = ['armeabi-v7a':1, 'arm64-v8a':2, 'mips':3, 'x86':4]
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.example.SanAngeles'

--- a/sensor-graph/accelerometer/build.gradle
+++ b/sensor-graph/accelerometer/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.android.accelerometergraph'

--- a/sensor-graph/accelerometer/build.gradle
+++ b/sensor-graph/accelerometer/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.android.accelerometergraph'

--- a/teapots/choreographer-30fps/build.gradle
+++ b/teapots/choreographer-30fps/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 29
     buildToolsVersion '29.0.3'
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.sample.choreographer'

--- a/teapots/classic-teapot/build.gradle
+++ b/teapots/classic-teapot/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 29
     buildToolsVersion '29.0.3'
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId = 'com.sample.teapot'

--- a/teapots/more-teapots/build.gradle
+++ b/teapots/more-teapots/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 29
     buildToolsVersion '29.0.3'
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId  'com.sample.moreteapots'

--- a/teapots/more-teapots/build.gradle
+++ b/teapots/more-teapots/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 
-
 android {
     compileSdkVersion 29
     buildToolsVersion '29.0.3'

--- a/teapots/textured-teapot/build.gradle
+++ b/teapots/textured-teapot/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 29
     buildToolsVersion '29.0.3'
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId = 'com.sample.texturedteapot'

--- a/webp/view/build.gradle
+++ b/webp/view/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
+    ndkVersion '21.1.6352462'
 
     defaultConfig {
         applicationId 'com.example.webp_view'

--- a/webp/view/build.gradle
+++ b/webp/view/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    ndkVersion '21.1.6352462'
+    ndkVersion '21.2.6472646'
 
     defaultConfig {
         applicationId 'com.example.webp_view'


### PR DESCRIPTION
On building the projects it gives out a warning:

```
WARNING: Support for ANDROID_NDK_HOME is deprecated and will be removed in the future. Use android.ndkVersion in build.gradle instead.
```

As per the docs too, having the `ndkVersion` is preferred way forward.

This PR builds upon #729 . It should be reviewed/merged after #729 is merged.