### PR TITLE
Update prefab sample's README.md to workaround SSL and LLDB conflict

### DIFF
--- a/prefab/curl-ssl/README.md
+++ b/prefab/curl-ssl/README.md
@@ -38,7 +38,7 @@ either in your `local.properties` file or on the command line by passing the
 To build with [Android Studio](http://developer.android.com/sdk/index.html):
 
 1. Open this project in Android Studio.
-2. Click *Run/Run 'app'.
+2. Click *Run/Run 'app'*.  If you want to debug/trace code, due to [the SSL lib's known issue with lldb](https://github.com/android/ndk-samples/issues/740), make sure to apply the recommendations there for a smooth debugging experience.
 
 To build from the command line:
 


### PR DESCRIPTION
Just incorporate https://github.com/android/ndk-samples/issues/740 into [README.md](https://github.com/android/ndk-samples/blob/master/prefab/curl-ssl/README.md)