### PR TITLE
Few types mismatch warnings fixed.

### DIFF
--- a/camera/common/utils/camera_utils.cpp
+++ b/camera/common/utils/camera_utils.cpp
@@ -326,7 +326,7 @@ void PrintTagVal(const char* printLabel, ACameraMetadata_const_entry& val) {
     return;
   }
   const char* name = GetTagStr(static_cast<acamera_metadata_tag_t>(val.tag));
-  for (int i = 0; i < val.count; ++i) {
+  for (uint32_t i = 0; i < val.count; ++i) {
     switch (val.type) {
       case ACAMERA_TYPE_INT32:
         LOGI("%s %s: %08d", printLabel, name, val.data.i32[i]);
@@ -409,7 +409,7 @@ void PrintRequestMetadata(ACaptureRequest* req) {
     const char* name =
         GetTagStr(static_cast<acamera_metadata_tag_t>(tags[idx]));
 
-    for (int i = 0; i < val.count; ++i) {
+    for (uint32_t i = 0; i < val.count; ++i) {
       switch (val.type) {
         case ACAMERA_TYPE_INT32:
           LOGI("Capture Tag %s: %08d", name, val.data.i32[i]);

--- a/camera/texture-view/src/main/cpp/camera_manager.cpp
+++ b/camera/texture-view/src/main/cpp/camera_manager.cpp
@@ -191,7 +191,7 @@ bool NDKCamera::MatchCaptureSizeRequest(int32_t requestWidth,
   DisplayDimension foundRes(4000, 4000);
   DisplayDimension maxJPG(0, 0);
 
-  for (int i = 0; i < entry.count; i += 4) {
+  for (uint32_t i = 0; i < entry.count; i += 4) {
     int32_t input = entry.data.i32[i + 3];
     int32_t format = entry.data.i32[i + 0];
     if (input) continue;

--- a/camera/texture-view/src/main/cpp/camera_manager.h
+++ b/camera/texture-view/src/main/cpp/camera_manager.h
@@ -91,7 +91,7 @@ class NDKCamera {
 
   // set up exposure control
   int64_t exposureTime_;
-  RangeValue<int64_t> exposureRange_;
+  RangeValue<uint64_t> exposureRange_;
   int32_t sensitivity_;
   RangeValue<int32_t> sensitivityRange_;
   volatile bool valid_;


### PR DESCRIPTION
Few type mismatch warnings are fixed for project `ndk-samples/camera/texture-view`. 

Unit Test: Compiled it locally and the warnings are gone. 

Note: Camera `exposureTime_` is measured in `ns` and it cannot be negative but the specs consider it to be `signed` it should be `unsigned`. Same is for `sensitivity_` too.