### PR TITLE
removed jcenter() from gradle project file, replaced with mavenCentral() fixes #801

### DIFF
--- a/camera/build.gradle
+++ b/camera/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
        google()
-       jcenter()
+       mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
@@ -12,6 +12,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }


### PR DESCRIPTION
Android Studio giving warning about this deprecation:
http://developer.android.com/r/tools/jcenter-end-of-service for more information.
Replaced with mavenCentral().
Tested for both basic and texture-view modules on Pixel3 running Android 11. 
Android Studio version 4.2.1 . 