### PR TITLE
Get U/V planes instead of V/U, and encode RGBA instead of BGRA.

### DIFF
--- a/camera/basic/src/main/cpp/image_reader.cpp
+++ b/camera/basic/src/main/cpp/image_reader.cpp
@@ -194,7 +194,7 @@ static inline uint32_t YUV2RGB(int nY, int nU, int nV) {
   nG = (nG >> 10) & 0xff;
   nB = (nB >> 10) & 0xff;
 
-  return 0xff000000 | (nR << 16) | (nG << 8) | nB;
+  return 0xff000000 | (nB << 16) | (nG << 8) | nR;
 }
 
 /**
@@ -258,8 +258,8 @@ void ImageReader::PresentImage(ANativeWindow_Buffer *buf, AImage *image) {
   AImage_getPlaneRowStride(image, 0, &yStride);
   AImage_getPlaneRowStride(image, 1, &uvStride);
   AImage_getPlaneData(image, 0, &yPixel, &yLen);
-  AImage_getPlaneData(image, 1, &vPixel, &vLen);
-  AImage_getPlaneData(image, 2, &uPixel, &uLen);
+  AImage_getPlaneData(image, 1, &uPixel, &uLen);
+  AImage_getPlaneData(image, 2, &vPixel, &vLen);
   int32_t uvPixelStride;
   AImage_getPlanePixelStride(image, 1, &uvPixelStride);
 
@@ -297,8 +297,8 @@ void ImageReader::PresentImage90(ANativeWindow_Buffer *buf, AImage *image) {
   AImage_getPlaneRowStride(image, 0, &yStride);
   AImage_getPlaneRowStride(image, 1, &uvStride);
   AImage_getPlaneData(image, 0, &yPixel, &yLen);
-  AImage_getPlaneData(image, 1, &vPixel, &vLen);
-  AImage_getPlaneData(image, 2, &uPixel, &uLen);
+  AImage_getPlaneData(image, 1, &uPixel, &uLen);
+  AImage_getPlaneData(image, 2, &vPixel, &vLen);
   int32_t uvPixelStride;
   AImage_getPlanePixelStride(image, 1, &uvPixelStride);
 
@@ -338,8 +338,8 @@ void ImageReader::PresentImage180(ANativeWindow_Buffer *buf, AImage *image) {
   AImage_getPlaneRowStride(image, 0, &yStride);
   AImage_getPlaneRowStride(image, 1, &uvStride);
   AImage_getPlaneData(image, 0, &yPixel, &yLen);
-  AImage_getPlaneData(image, 1, &vPixel, &vLen);
-  AImage_getPlaneData(image, 2, &uPixel, &uLen);
+  AImage_getPlaneData(image, 1, &uPixel, &uLen);
+  AImage_getPlaneData(image, 2, &vPixel, &vLen);
   int32_t uvPixelStride;
   AImage_getPlanePixelStride(image, 1, &uvPixelStride);
 
@@ -380,8 +380,8 @@ void ImageReader::PresentImage270(ANativeWindow_Buffer *buf, AImage *image) {
   AImage_getPlaneRowStride(image, 0, &yStride);
   AImage_getPlaneRowStride(image, 1, &uvStride);
   AImage_getPlaneData(image, 0, &yPixel, &yLen);
-  AImage_getPlaneData(image, 1, &vPixel, &vLen);
-  AImage_getPlaneData(image, 2, &uPixel, &uLen);
+  AImage_getPlaneData(image, 1, &uPixel, &uLen);
+  AImage_getPlaneData(image, 2, &vPixel, &vLen);
   int32_t uvPixelStride;
   AImage_getPlanePixelStride(image, 1, &uvPixelStride);
 


### PR DESCRIPTION
The U and V planes are swapped [here](https://github.com/android/ndk-samples/blob/main/camera/basic/src/main/cpp/image_reader.cpp#L257):

      AImage_getPlaneData(image, 0, &yPixel, &yLen);
      AImage_getPlaneData(image, 1, &vPixel, &vLen);
      AImage_getPlaneData(image, 2, &uPixel, &uLen);

According to [the docs](https://developer.android.com/ndk/reference/group/media#group___media_1gga9c3dace30485a0f28163a882a5d65a19aea9797f9b5db5d26a2055a43d8491890):

> The order of planes is guaranteed such that plane #0 is always Y, plane #1 is always U (Cb), and plane #2 is always V (Cr).

This works out because [the function YUV2RGB](https://github.com/android/ndk-samples/blob/main/camera/basic/src/main/cpp/image_reader.cpp#L193) actually encodes BGRA, not RGBA:

      return 0xff000000 | (nR << 16) | (nG << 8) | nB;

(Swapping U and V is equivalent to swapping R and B.)