### PR TITLE
Updating hello-jnicallback to support large screen devices

### DIFF
--- a/hello-jniCallback/app/src/main/cpp/hello-jnicallback.c
+++ b/hello-jniCallback/app/src/main/cpp/hello-jnicallback.c
@@ -284,7 +284,7 @@ Java_com_example_hellojnicallback_MainActivity_startTicks(JNIEnv *env, jobject i
  *    for a clean shutdown. The caller is from onPause
  */
 JNIEXPORT void JNICALL
-Java_com_example_hellojnicallback_MainActivity_StopTicks(JNIEnv *env, jobject instance) {
+Java_com_example_hellojnicallback_MainActivity_stopTicks(JNIEnv *env, jobject instance) {
     pthread_mutex_lock(&g_ctx.lock);
     g_ctx.done = 1;
     pthread_mutex_unlock(&g_ctx.lock);

--- a/hello-jniCallback/app/src/main/java/com/example/hellojnicallback/MainViewModel.java
+++ b/hello-jniCallback/app/src/main/java/com/example/hellojnicallback/MainViewModel.java
@@ -1,0 +1,31 @@
+package com.example.hellojnicallback;
+
+import androidx.lifecycle.ViewModel;
+
+public class MainViewModel extends ViewModel {
+    private int hour = 0;
+    private int minute = 0;
+    private int second = 0;
+    public boolean started = false;
+    public boolean running = false;
+
+    public void updateTimer() {
+        ++second;
+        if(second >= 60) {
+            ++minute;
+            second -= 60;
+            if(minute >= 60) {
+                ++hour;
+                minute -= 60;
+            }
+        }
+    }
+
+    public void resetTimer() {
+        hour = minute = second = 0;
+    }
+
+    public String time() {
+        return hour + ":" + minute + ":" + second;
+    }
+}

--- a/hello-jniCallback/app/src/main/res/layout/activity_main.xml
+++ b/hello-jniCallback/app/src/main/res/layout/activity_main.xml
@@ -43,5 +43,16 @@
         app:layout_constraintBottom_toBottomOf="@+id/activity_hello_jnicallback"
         tools:layout_constraintBottom_creator="0" />
 
+    <Button
+        android:id="@+id/pauseBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="48dp"
+        android:layout_marginTop="32dp"
+        android:onClick="onPauseBtn"
+        android:text="Button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tickView" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/hello-jniCallback/app/src/main/res/values/strings.xml
+++ b/hello-jniCallback/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">Hello-jniCallback</string>
+    <string name="pause">PAUSE</string>
+    <string name="resume">RESUME</string>
 </resources>


### PR DESCRIPTION
Timer does not restart on configuration changes and utilizes a ViewModel to preserve state. Timer functionality refactored into this ViewModel.
Button added to start and stop.
Changed StopTimer to stopTimer to match naming convention.