### PR TITLE
Upate gradle files to reflect current app templates.

### DIFF
--- a/.ci_tools/build_samples.sh
+++ b/.ci_tools/build_samples.sh
@@ -64,7 +64,7 @@ fi
 for d in "${projects[@]}"; do
     pushd ${NDK_SAMPLE_REPO}/${d} >/dev/null
     echo "Building ${d}"
-    TERM=dumb ./gradlew ${VERBOSITY} assembleDebug
+    TERM=dumb ./gradlew ${VERBOSITY} clean assembleDebug
     popd >/dev/null
 done
 

--- a/.ci_tools/build_samples.sh
+++ b/.ci_tools/build_samples.sh
@@ -17,6 +17,7 @@ declare projects=(
     audio-echo
     bitmap-plasma
     camera
+    display-p3
     endless-tunnel
     gles3jni
     hello-gl2
@@ -24,18 +25,21 @@ declare projects=(
     hello-jniCallback
     hello-libs
     hello-neon
+    hello-oboe
     native-activity
     native-audio
     native-codec
     native-media
+    native-midi
     native-plasma
     nn-samples
     prefab/curl-ssl
+    prefab/prefab-dependency
     prefab/prefab-publishing
     san-angeles
     sensor-graph
-#    webp
     teapots
+    webp
 ##   ndk-build samples
     other-builds/ndkbuild/bitmap-plasma
     other-builds/ndkbuild/gles3jni
@@ -54,13 +58,13 @@ declare projects=(
     )
 
 VERBOSITY=--quiet
-if [[ -v RUNNER_DEBUG ]] ; then
+if [ -n "${RUNNER_DEBUG+1}" ] ; then
     VERBOSITY=--info
 fi
 for d in "${projects[@]}"; do
     pushd ${NDK_SAMPLE_REPO}/${d} >/dev/null
     echo "Building ${d}"
-    TERM=dumb ./gradlew ${VERBOSITY} clean assembleDebug
+    TERM=dumb ./gradlew ${VERBOSITY} assembleDebug
     popd >/dev/null
 done
 
@@ -71,6 +75,7 @@ declare apks=(
   bitmap-plasma/app/build/outputs/apk/debug/app-debug.apk
   camera/basic/build/outputs/apk/debug/basic-debug.apk
   camera/texture-view/build/outputs/apk/debug/texture-view-debug.apk
+  display-p3/image-view/build/outputs/apk/debug/image-view-debug.apk
   endless-tunnel/app/build/outputs/apk/debug/app-debug.apk
   gles3jni/app/build/outputs/apk/debug/app-debug.apk
   hello-gl2/app/build/outputs/apk/debug/app-debug.apk
@@ -78,15 +83,18 @@ declare apks=(
   hello-jniCallback/app/build/outputs/apk/debug/app-debug.apk
   hello-libs/app/build/outputs/apk/debug/app-debug.apk
   hello-neon/app/build/outputs/apk/debug/app-debug.apk
+  hello-oboe/app/build/outputs/apk/debug/app-debug.apk
   native-activity/app/build/outputs/apk/debug/app-debug.apk
   native-audio/app/build/outputs/apk/debug/app-debug.apk
   native-codec/app/build/outputs/apk/debug/app-debug.apk
   native-media/app/build/outputs/apk/debug/app-debug.apk
+  native-midi/app/build/outputs/apk/debug/app-debug.apk
   native-plasma/app/build/outputs/apk/debug/app-debug.apk
   nn-samples/basic/build/outputs/apk/debug/basic-debug.apk
   nn-samples/sequence/build/outputs/apk/debug/sequence-debug.apk
   prefab/curl-ssl/app/build/outputs/apk/debug/app-debug.apk
   prefab/prefab-publishing/mylibrary/build/outputs/aar/mylibrary-debug.aar
+  prefab/prefab-dependency/app/build/outputs/apk/debug/app-debug.apk
   sensor-graph/accelerometer/build/outputs/apk/debug/accelerometer-debug.apk
   san-angeles/app/build/outputs/apk/debug/app-armeabi-v7a-debug.apk
   san-angeles/app/build/outputs/apk/debug/app-arm64-v8a-debug.apk
@@ -95,7 +103,7 @@ declare apks=(
   teapots/more-teapots/build/outputs/apk/debug/more-teapots-debug.apk
   teapots/choreographer-30fps/build/outputs/apk/debug/choreographer-30fps-debug.apk
   teapots/image-decoder/build/outputs/apk/debug/image-decoder-debug.apk
-#    webp/view/build/outputs/apk/debug/view-arm7-debug.apk
+  webp/view/build/outputs/apk/debug/view-debug.apk
 
 ## other-builds
   other-builds/ndkbuild/bitmap-plasma/app/build/outputs/apk/debug/app-debug.apk

--- a/.ci_tools/setup_env.sh
+++ b/.ci_tools/setup_env.sh
@@ -76,7 +76,7 @@ fi
 TMP_SETUP_FILENAME=versions_.txt
 
 ## Retrieve all necessary Android Platforms and install them all
-retrieve_versions compileSdkVersion $TMP_SETUP_FILENAME
+retrieve_versions compileSdk $TMP_SETUP_FILENAME
 
 # Install platforms
 while read -r version_; do

--- a/audio-echo/app/build.gradle
+++ b/audio-echo/app/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.google.sample.echo'

--- a/audio-echo/build.gradle
+++ b/audio-echo/build.gradle
@@ -1,21 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/audio-echo/gradle/wrapper/gradle-wrapper.properties
+++ b/audio-echo/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/audio-echo/settings.gradle
+++ b/audio-echo/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/bitmap-plasma/app/build.gradle
+++ b/bitmap-plasma/app/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig.with {
         applicationId 'com.example.plasma'

--- a/bitmap-plasma/build.gradle
+++ b/bitmap-plasma/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/bitmap-plasma/gradle/wrapper/gradle-wrapper.properties
+++ b/bitmap-plasma/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/bitmap-plasma/settings.gradle
+++ b/bitmap-plasma/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/builder/gradle/wrapper/gradle-wrapper.properties
+++ b/builder/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/camera/basic/build.gradle
+++ b/camera/basic/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.sample.camera.basic'

--- a/camera/build.gradle
+++ b/camera/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/camera/gradle/wrapper/gradle-wrapper.properties
+++ b/camera/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/camera/settings.gradle
+++ b/camera/settings.gradle
@@ -1,2 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':basic'
 include ':texture-view'

--- a/camera/texture-view/build.gradle
+++ b/camera/texture-view/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId "com.sample.textureview"

--- a/display-p3/build.gradle
+++ b/display-p3/build.gradle
@@ -1,19 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {

--- a/display-p3/gradle/wrapper/gradle-wrapper.properties
+++ b/display-p3/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/display-p3/image-view/build.gradle
+++ b/display-p3/image-view/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId = 'com.example.widecolor'

--- a/display-p3/settings.gradle
+++ b/display-p3/settings.gradle
@@ -1,2 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':image-view'
 

--- a/endless-tunnel/app/build.gradle
+++ b/endless-tunnel/app/build.gradle
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.google.sample.tunnel'

--- a/endless-tunnel/build.gradle
+++ b/endless-tunnel/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/endless-tunnel/gradle/wrapper/gradle-wrapper.properties
+++ b/endless-tunnel/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/endless-tunnel/settings.gradle
+++ b/endless-tunnel/settings.gradle
@@ -14,4 +14,18 @@
  * limitations under the License.
  */
 
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/gles3jni/app/build.gradle
+++ b/gles3jni/app/build.gradle
@@ -1,12 +1,14 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 def platformVersion = 24      // openGLES 3.2 min api level
 // def platformVersion = 18    //openGLES 3 min api level
 // def platformVersion = 12    //openGLES 2 min api level
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.android.gles3jni'

--- a/gles3jni/build.gradle
+++ b/gles3jni/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/gles3jni/gradle/wrapper/gradle-wrapper.properties
+++ b/gles3jni/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gles3jni/settings.gradle
+++ b/gles3jni/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/hello-gl2/app/build.gradle
+++ b/hello-gl2/app/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
     
     defaultConfig {
         applicationId 'com.android.gl2jni'

--- a/hello-gl2/build.gradle
+++ b/hello-gl2/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/hello-gl2/gradle/wrapper/gradle-wrapper.properties
+++ b/hello-gl2/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hello-gl2/settings.gradle
+++ b/hello-gl2/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/hello-jni/app/build.gradle
+++ b/hello-jni/app/build.gradle
@@ -1,10 +1,11 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.example.hellojni'
@@ -54,5 +55,5 @@ android {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10"
 }

--- a/hello-jni/build.gradle
+++ b/hello-jni/build.gradle
@@ -1,25 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    ext.kotlin_version = '1.3.72'
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {

--- a/hello-jni/gradle/wrapper/gradle-wrapper.properties
+++ b/hello-jni/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hello-jni/settings.gradle
+++ b/hello-jni/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/hello-jniCallback/app/build.gradle
+++ b/hello-jniCallback/app/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
     
     defaultConfig {
         applicationId 'com.example.hellojnicallback'

--- a/hello-jniCallback/build.gradle
+++ b/hello-jniCallback/build.gradle
@@ -1,23 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {

--- a/hello-jniCallback/gradle/wrapper/gradle-wrapper.properties
+++ b/hello-jniCallback/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hello-jniCallback/settings.gradle
+++ b/hello-jniCallback/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/hello-libs/app/build.gradle
+++ b/hello-libs/app/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId = 'com.example.hellolibs'

--- a/hello-libs/build.gradle
+++ b/hello-libs/build.gradle
@@ -1,23 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {

--- a/hello-libs/gen-libs/build.gradle
+++ b/hello-libs/gen-libs/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.library'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         minSdkVersion 14

--- a/hello-libs/gradle/wrapper/gradle-wrapper.properties
+++ b/hello-libs/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hello-libs/settings.gradle
+++ b/hello-libs/settings.gradle
@@ -1,3 +1,17 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'
 
 // To generate libs used in this sample:

--- a/hello-neon/app/build.gradle
+++ b/hello-neon/app/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
     
     defaultConfig {
         applicationId "com.example.helloneon"

--- a/hello-neon/build.gradle
+++ b/hello-neon/build.gradle
@@ -1,23 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {

--- a/hello-neon/gradle/wrapper/gradle-wrapper.properties
+++ b/hello-neon/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hello-neon/settings.gradle
+++ b/hello-neon/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/hello-oboe/app/build.gradle
+++ b/hello-oboe/app/build.gradle
@@ -1,12 +1,11 @@
-apply plugin: 'com.android.application'
-
-apply plugin: 'kotlin-android'
-
-apply plugin: 'kotlin-android-extensions'
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
     
     defaultConfig {
         applicationId "com.google.example.hellooboe"
@@ -30,13 +29,16 @@ android {
             version "3.18.1"
         }
     }
-    buildFeatures.prefab = true
+    buildFeatures {
+        prefab = true
+        viewBinding = true
+    }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     // Kotlin
-    implementation"org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation"org.jetbrains.kotlin:kotlin-stdlib:1.7.10"
 
     // AndroidX
     implementation 'androidx.appcompat:appcompat:1.1.0'

--- a/hello-oboe/app/src/main/java/com/google/example/hellooboe/MainActivity.kt
+++ b/hello-oboe/app/src/main/java/com/google/example/hellooboe/MainActivity.kt
@@ -22,13 +22,17 @@ import android.os.Bundle
 import android.view.MotionEvent
 import android.view.View
 import android.widget.Toast
-import kotlinx.android.synthetic.main.activity_main.sample_text
+import com.google.example.hellooboe.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
 
+    private lateinit var binding: ActivityMainBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        val view = binding.root
+        setContentView(view)
     }
 
     /*
@@ -50,7 +54,7 @@ class MainActivity : AppCompatActivity() {
         if (createStream() != 0) {
             val errorString : String = getString(R.string.error_msg)
             Toast.makeText(applicationContext, errorString,Toast.LENGTH_LONG).show()
-            sample_text.text = errorString
+            binding.sampleText.text = errorString
         }
     }
 

--- a/hello-oboe/build.gradle
+++ b/hello-oboe/build.gradle
@@ -1,25 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    ext.kotlin_version = '1.3.72'
-    repositories {
-        google()
-        mavenCentral()
-        
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {

--- a/hello-oboe/gradle/wrapper/gradle-wrapper.properties
+++ b/hello-oboe/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Nov 17 16:35:15 CST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/hello-oboe/settings.gradle
+++ b/hello-oboe/settings.gradle
@@ -1,2 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'
 rootProject.name='Hello Oboe'

--- a/native-activity/app/build.gradle
+++ b/native-activity/app/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId = 'com.example.native_activity'

--- a/native-activity/build.gradle
+++ b/native-activity/build.gradle
@@ -1,19 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {

--- a/native-activity/gradle/wrapper/gradle-wrapper.properties
+++ b/native-activity/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/native-activity/settings.gradle
+++ b/native-activity/settings.gradle
@@ -1,2 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'
 

--- a/native-audio/app/build.gradle
+++ b/native-audio/app/build.gradle
@@ -1,10 +1,12 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-     compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
-     defaultConfig {
+    defaultConfig {
         applicationId 'com.example.nativeaudio'
         minSdkVersion 23
         targetSdkVersion 28

--- a/native-audio/build.gradle
+++ b/native-audio/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/native-audio/gradle/wrapper/gradle-wrapper.properties
+++ b/native-audio/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/native-audio/settings.gradle
+++ b/native-audio/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/native-codec/app/build.gradle
+++ b/native-codec/app/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.example.nativecodec'

--- a/native-codec/build.gradle
+++ b/native-codec/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/native-codec/gradle/wrapper/gradle-wrapper.properties
+++ b/native-codec/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/native-codec/settings.gradle
+++ b/native-codec/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/native-media/app/build.gradle
+++ b/native-media/app/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.example.nativemedia'

--- a/native-media/build.gradle
+++ b/native-media/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/native-media/gradle/wrapper/gradle-wrapper.properties
+++ b/native-media/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/native-media/settings.gradle
+++ b/native-media/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/native-midi/app/build.gradle
+++ b/native-midi/app/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
     
     defaultConfig {
         applicationId "com.example.nativemidi"

--- a/native-midi/app/src/main/cpp/AppMidiManager.cpp
+++ b/native-midi/app/src/main/cpp/AppMidiManager.cpp
@@ -148,13 +148,12 @@ extern "C" {
 void Java_com_example_nativemidi_AppMidiManager_startReadingMidi(
         JNIEnv* env, jobject, jobject midiDeviceObj, jint portNumber) {
 
-    media_status_t status;
-    status = AMidiDevice_fromJava(env, midiDeviceObj, &sNativeReceiveDevice);
+    AMidiDevice_fromJava(env, midiDeviceObj, &sNativeReceiveDevice);
     // int32_t deviceType = AMidiDevice_getType(sNativeReceiveDevice);
     // ssize_t numPorts = AMidiDevice_getNumOutputPorts(sNativeReceiveDevice);
 
     AMidiOutputPort *outputPort;
-    status = AMidiOutputPort_open(sNativeReceiveDevice, portNumber, &outputPort);
+    AMidiOutputPort_open(sNativeReceiveDevice, portNumber, &outputPort);
 
     // sMidiOutputPort.store(outputPort);
     sMidiOutputPort = outputPort;
@@ -192,13 +191,12 @@ void Java_com_example_nativemidi_AppMidiManager_stopReadingMidi(JNIEnv*, jobject
 void Java_com_example_nativemidi_AppMidiManager_startWritingMidi(
         JNIEnv* env, jobject, jobject midiDeviceObj, jint portNumber) {
 
-    media_status_t status;
-    status = AMidiDevice_fromJava(env, midiDeviceObj, &sNativeSendDevice);
+    AMidiDevice_fromJava(env, midiDeviceObj, &sNativeSendDevice);
     // int32_t deviceType = AMidiDevice_getType(sNativeReceiveDevice);
     // ssize_t numPorts = AMidiDevice_getNumInputPorts(sNativeSendDevice);
 
     AMidiInputPort *inputPort;
-    status = AMidiInputPort_open(sNativeSendDevice, portNumber, &inputPort);
+    AMidiInputPort_open(sNativeSendDevice, portNumber, &inputPort);
     // sMidiInputPort.store(inputPort);
     sMidiInputPort = inputPort;
 }

--- a/native-midi/build.gradle
+++ b/native-midi/build.gradle
@@ -1,25 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-        
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-        
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {

--- a/native-midi/gradle/wrapper/gradle-wrapper.properties
+++ b/native-midi/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/native-midi/settings.gradle
+++ b/native-midi/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/native-plasma/app/build.gradle
+++ b/native-plasma/app/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.example.native_plasma'

--- a/native-plasma/build.gradle
+++ b/native-plasma/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/native-plasma/gradle/wrapper/gradle-wrapper.properties
+++ b/native-plasma/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/native-plasma/settings.gradle
+++ b/native-plasma/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/nn-samples/basic/build.gradle
+++ b/nn-samples/basic/build.gradle
@@ -1,10 +1,11 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
 
 android {
-    compileSdkVersion 30
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId "com.example.android.basic"
@@ -42,10 +43,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0"
-}
-repositories {
-    mavenCentral()
 }

--- a/nn-samples/build.gradle
+++ b/nn-samples/build.gradle
@@ -1,25 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    ext.kotlin_version = '1.3.72'
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {

--- a/nn-samples/gradle/wrapper/gradle-wrapper.properties
+++ b/nn-samples/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/nn-samples/sequence/build.gradle
+++ b/nn-samples/sequence/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 30
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId "com.example.android.sequence"

--- a/nn-samples/settings.gradle
+++ b/nn-samples/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':basic', ':sequence'

--- a/other-builds/ndkbuild/bitmap-plasma/app/build.gradle
+++ b/other-builds/ndkbuild/bitmap-plasma/app/build.gradle
@@ -1,12 +1,14 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 // pointing to cmake's source code for the same project
 def REMOTE_PROJ_ROOT = '../../../../' + rootProject.getName() + '/' +
                         project.getName() + '/src/main'
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId "com.example.plasma"

--- a/other-builds/ndkbuild/bitmap-plasma/build.gradle
+++ b/other-builds/ndkbuild/bitmap-plasma/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/other-builds/ndkbuild/bitmap-plasma/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/bitmap-plasma/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/bitmap-plasma/settings.gradle
+++ b/other-builds/ndkbuild/bitmap-plasma/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/other-builds/ndkbuild/gles3jni/app/build.gradle
+++ b/other-builds/ndkbuild/gles3jni/app/build.gradle
@@ -5,15 +5,17 @@
  *      command line argument APP_PLATFORM=android-11 (or lower)
  */
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 // pointing to cmake's source code for the same project
 def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
                        project.getName() + '/src/main'
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.android.gles3jni'

--- a/other-builds/ndkbuild/gles3jni/build.gradle
+++ b/other-builds/ndkbuild/gles3jni/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/other-builds/ndkbuild/gles3jni/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/gles3jni/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/gles3jni/settings.gradle
+++ b/other-builds/ndkbuild/gles3jni/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/other-builds/ndkbuild/hello-gl2/app/build.gradle
+++ b/other-builds/ndkbuild/hello-gl2/app/build.gradle
@@ -1,11 +1,14 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
+
 // pointing to cmake's source code for the same project
 def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
         project.getName() + '/src/main'
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
     
     defaultConfig {
         applicationId 'com.android.gl2jni'

--- a/other-builds/ndkbuild/hello-gl2/build.gradle
+++ b/other-builds/ndkbuild/hello-gl2/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/other-builds/ndkbuild/hello-gl2/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/hello-gl2/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/hello-gl2/settings.gradle
+++ b/other-builds/ndkbuild/hello-gl2/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/other-builds/ndkbuild/hello-jni/app/build.gradle
+++ b/other-builds/ndkbuild/hello-jni/app/build.gradle
@@ -1,13 +1,14 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
 
 // pointing to cmake's source code for the same project
 def REMOTE_PROJ_ROOT = '../../../../' + rootProject.getName() + '/' +
                         project.getName() + '/src/main'
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId "com.example.hellojni"
@@ -44,6 +45,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10"
 }
 

--- a/other-builds/ndkbuild/hello-jni/build.gradle
+++ b/other-builds/ndkbuild/hello-jni/build.gradle
@@ -1,20 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    ext.kotlin_version = '1.3.72'
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }
-

--- a/other-builds/ndkbuild/hello-jni/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/hello-jni/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/hello-jni/settings.gradle
+++ b/other-builds/ndkbuild/hello-jni/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/other-builds/ndkbuild/hello-libs/app/build.gradle
+++ b/other-builds/ndkbuild/hello-libs/app/build.gradle
@@ -2,15 +2,17 @@
 //  generate 2 libs on terminal ( or command line )
 //  please refer to ${project}/gen-libs/gen_lib.sh for details
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 // pointing to cmake's source code for the same project
 def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
         project.getName() + '/src/main'
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId = 'com.example.hellolibs'

--- a/other-builds/ndkbuild/hello-libs/build.gradle
+++ b/other-builds/ndkbuild/hello-libs/build.gradle
@@ -1,23 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {

--- a/other-builds/ndkbuild/hello-libs/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/hello-libs/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/hello-libs/settings.gradle
+++ b/other-builds/ndkbuild/hello-libs/settings.gradle
@@ -1,3 +1,17 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'
 
 

--- a/other-builds/ndkbuild/hello-neon/app/build.gradle
+++ b/other-builds/ndkbuild/hello-neon/app/build.gradle
@@ -1,11 +1,14 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
+
 // pointing to cmake's source code for the same project
 def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
         project.getName() + '/src/main'
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
     
     defaultConfig {
         applicationId "com.example.helloneon"

--- a/other-builds/ndkbuild/hello-neon/build.gradle
+++ b/other-builds/ndkbuild/hello-neon/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/other-builds/ndkbuild/hello-neon/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/hello-neon/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/hello-neon/settings.gradle
+++ b/other-builds/ndkbuild/hello-neon/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/other-builds/ndkbuild/native-activity/app/build.gradle
+++ b/other-builds/ndkbuild/native-activity/app/build.gradle
@@ -1,12 +1,14 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 // pointing to cmake's source code for the same project
 def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
         project.getName() + '/src/main'
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId = 'com.example.native_activity'

--- a/other-builds/ndkbuild/native-activity/build.gradle
+++ b/other-builds/ndkbuild/native-activity/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/other-builds/ndkbuild/native-activity/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/native-activity/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/native-activity/settings.gradle
+++ b/other-builds/ndkbuild/native-activity/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/other-builds/ndkbuild/native-audio/app/build.gradle
+++ b/other-builds/ndkbuild/native-audio/app/build.gradle
@@ -1,13 +1,16 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
+
 // pointing to cmake's source code for the same project
 def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
         project.getName() + '/src/main'
 
 android {
-     compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
-     defaultConfig {
+    defaultConfig {
         applicationId 'com.example.nativeaudio'
         minSdkVersion 14
         targetSdkVersion 28

--- a/other-builds/ndkbuild/native-audio/build.gradle
+++ b/other-builds/ndkbuild/native-audio/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/other-builds/ndkbuild/native-audio/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/native-audio/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/native-audio/settings.gradle
+++ b/other-builds/ndkbuild/native-audio/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/other-builds/ndkbuild/native-codec/app/build.gradle
+++ b/other-builds/ndkbuild/native-codec/app/build.gradle
@@ -1,12 +1,14 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 // pointing to cmake's source code for the same project
 def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
         project.getName() + '/src/main'
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.example.nativecodec'

--- a/other-builds/ndkbuild/native-codec/build.gradle
+++ b/other-builds/ndkbuild/native-codec/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/other-builds/ndkbuild/native-codec/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/native-codec/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/native-codec/settings.gradle
+++ b/other-builds/ndkbuild/native-codec/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/other-builds/ndkbuild/native-media/app/build.gradle
+++ b/other-builds/ndkbuild/native-media/app/build.gradle
@@ -1,11 +1,14 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
+
 // pointing to cmake's source code for the same project
 def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
         project.getName() + '/src/main'
 
 android {
-     compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
      defaultConfig {
         applicationId 'com.example.nativemedia'

--- a/other-builds/ndkbuild/native-media/build.gradle
+++ b/other-builds/ndkbuild/native-media/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/other-builds/ndkbuild/native-media/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/native-media/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/native-media/settings.gradle
+++ b/other-builds/ndkbuild/native-media/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/other-builds/ndkbuild/native-plasma/app/build.gradle
+++ b/other-builds/ndkbuild/native-plasma/app/build.gradle
@@ -1,12 +1,14 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 // pointing to cmake's source code for the same project
 def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
         project.getName() + '/src/main'
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.example.native_plasma'

--- a/other-builds/ndkbuild/native-plasma/build.gradle
+++ b/other-builds/ndkbuild/native-plasma/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/other-builds/ndkbuild/native-plasma/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/native-plasma/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/native-plasma/settings.gradle
+++ b/other-builds/ndkbuild/native-plasma/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/other-builds/ndkbuild/nn-samples/basic/build.gradle
+++ b/other-builds/ndkbuild/nn-samples/basic/build.gradle
@@ -1,14 +1,15 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
 
 // pointing to cmake's source code for the same project
 def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
         project.getName() + '/src/main'
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId "com.example.android.basic"
@@ -41,7 +42,7 @@ android {
 }
 dependencies {
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0"
 }

--- a/other-builds/ndkbuild/nn-samples/build.gradle
+++ b/other-builds/ndkbuild/nn-samples/build.gradle
@@ -1,19 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    ext.kotlin_version = '1.3.72'
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/other-builds/ndkbuild/nn-samples/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/nn-samples/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/other-builds/ndkbuild/nn-samples/settings.gradle
+++ b/other-builds/ndkbuild/nn-samples/settings.gradle
@@ -1,2 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':basic'
 

--- a/other-builds/ndkbuild/san-angeles/app/build.gradle
+++ b/other-builds/ndkbuild/san-angeles/app/build.gradle
@@ -1,6 +1,8 @@
 // To demo apk split feature as documented at
 // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits#TOC-ABIs-Splits
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 // pointing to cmake's source code for the same project
 def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
@@ -10,8 +12,8 @@ import com.android.build.OutputFile
 ext.versionCodes = ['armeabi-v7a':1, 'arm64-v8a':2, 'x86':3]
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.example.SanAngeles'

--- a/other-builds/ndkbuild/san-angeles/build.gradle
+++ b/other-builds/ndkbuild/san-angeles/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/other-builds/ndkbuild/san-angeles/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/san-angeles/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/san-angeles/settings.gradle
+++ b/other-builds/ndkbuild/san-angeles/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/other-builds/ndkbuild/teapots/build.gradle
+++ b/other-builds/ndkbuild/teapots/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/other-builds/ndkbuild/teapots/classic-teapot/build.gradle
+++ b/other-builds/ndkbuild/teapots/classic-teapot/build.gradle
@@ -1,12 +1,14 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 // pointing to cmake's source code for the same project
 def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
         project.getName() + '/src/main'
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId "com.sample.teapot"

--- a/other-builds/ndkbuild/teapots/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/teapots/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/teapots/more-teapots/build.gradle
+++ b/other-builds/ndkbuild/teapots/more-teapots/build.gradle
@@ -1,12 +1,14 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 // pointing to cmake's source code for the same project
 def REMOTE_SRC_ROOT = '../../../../' + rootProject.getName() + '/' +
         project.getName() + '/src/main'
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId "com.sample.moreteapots"

--- a/other-builds/ndkbuild/teapots/settings.gradle
+++ b/other-builds/ndkbuild/teapots/settings.gradle
@@ -1,2 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':classic-teapot',':more-teapots'
 

--- a/other-builds/ndkbuild/two-libs/app/build.gradle
+++ b/other-builds/ndkbuild/two-libs/app/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId "com.example.twolibs"

--- a/other-builds/ndkbuild/two-libs/build.gradle
+++ b/other-builds/ndkbuild/two-libs/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/other-builds/ndkbuild/two-libs/gradle/wrapper/gradle-wrapper.properties
+++ b/other-builds/ndkbuild/two-libs/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/other-builds/ndkbuild/two-libs/settings.gradle
+++ b/other-builds/ndkbuild/two-libs/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/prefab/curl-ssl/app/build.gradle
+++ b/prefab/curl-ssl/app/build.gradle
@@ -16,13 +16,12 @@
 
 plugins {
     id 'com.android.application'
-    id 'kotlin-android'
-    id 'kotlin-android-extensions'
+    id 'org.jetbrains.kotlin.android'
 }
 
 android {
-    compileSdkVersion 30
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
     defaultConfig {
         applicationId "com.example.curlssl"
         minSdkVersion 21
@@ -62,7 +61,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10"
     implementation 'com.android.support:appcompat-v7:30.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation "com.android.ndk.thirdparty:curl:7.79.1-beta-1"

--- a/prefab/curl-ssl/build.gradle
+++ b/prefab/curl-ssl/build.gradle
@@ -14,23 +14,11 @@
  * limitations under the License.
  */
 
-buildscript {
-    ext.kotlin_version = '1.3.61'
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {

--- a/prefab/curl-ssl/gradle/wrapper/gradle-wrapper.properties
+++ b/prefab/curl-ssl/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/prefab/curl-ssl/settings.gradle
+++ b/prefab/curl-ssl/settings.gradle
@@ -1,2 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 rootProject.name='curl-ssl'
 include ':app'

--- a/prefab/prefab-dependency/app/build.gradle
+++ b/prefab/prefab-dependency/app/build.gradle
@@ -16,20 +16,22 @@
 
 plugins {
     id  'com.android.application'
-    id  'kotlin-android'
-    id  'kotlin-android-extensions'
+    id 'org.jetbrains.kotlin.android'
 }
 
 android {
-    compileSdkVersion 30
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
-    buildFeatures.prefab = true
+    buildFeatures {
+        prefab = true
+        viewBinding = true
+    }
 
     defaultConfig {
         applicationId "com.example.com.example.prefabdependency"
         minSdkVersion 21
         targetSdkVersion 30
-        ndkVersion '22.1.7171670'
         versionCode 1
         versionName "1.0"
 
@@ -64,7 +66,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10"
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation "com.android.ndk.thirdparty:jsoncpp:1.8.4-alpha-1"

--- a/prefab/prefab-dependency/app/src/main/java/com/example/prefabdependency/MainActivity.kt
+++ b/prefab/prefab-dependency/app/src/main/java/com/example/prefabdependency/MainActivity.kt
@@ -18,18 +18,18 @@ package com.example.prefabdependency
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.android.synthetic.main.activity_json_parse.*
+import com.example.prefabdependency.databinding.ActivityJsonParseBinding
 
 class MainActivity : AppCompatActivity() {
 
+    private lateinit var binding: ActivityJsonParseBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        /* Retrieve our TextView and set its content.
-         * the text is retrieved by calling a native
-         * function.
-         */
-        setContentView(R.layout.activity_json_parse)
-        result_textview.text = getJsonValue(
+        binding = ActivityJsonParseBinding.inflate(layoutInflater)
+        val view = binding.root
+        setContentView(view)
+        binding.resultTextview.text = getJsonValue(
             """
             {
                 "cpp": "clang",

--- a/prefab/prefab-dependency/build.gradle
+++ b/prefab/prefab-dependency/build.gradle
@@ -14,23 +14,11 @@
  * limitations under the License.
  */
 
-buildscript {
-    ext.kotlin_version = '1.3.61'
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {

--- a/prefab/prefab-dependency/gradle/wrapper/gradle-wrapper.properties
+++ b/prefab/prefab-dependency/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/prefab/prefab-dependency/settings.gradle
+++ b/prefab/prefab-dependency/settings.gradle
@@ -1,2 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 rootProject.name='prefab-dependency'
 include ':app'

--- a/prefab/prefab-publishing/build.gradle
+++ b/prefab/prefab-publishing/build.gradle
@@ -14,21 +14,11 @@
  * limitations under the License.
  */
 
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
 task clean(type: Delete) {

--- a/prefab/prefab-publishing/gradle/wrapper/gradle-wrapper.properties
+++ b/prefab/prefab-publishing/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Nov 15 13:10:49 CST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/prefab/prefab-publishing/mylibrary/build.gradle
+++ b/prefab/prefab-publishing/mylibrary/build.gradle
@@ -19,8 +19,8 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         minSdkVersion 16

--- a/prefab/prefab-publishing/settings.gradle
+++ b/prefab/prefab-publishing/settings.gradle
@@ -1,2 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 rootProject.name='prefab-publishing'
 include ':mylibrary'

--- a/san-angeles/app/build.gradle
+++ b/san-angeles/app/build.gradle
@@ -1,13 +1,15 @@
 // To demo apk split feature as documented at
 // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits#TOC-ABIs-Splits
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 import com.android.build.OutputFile
 ext.versionCodes = ['armeabi-v7a':1, 'arm64-v8a':2, 'mips':3, 'x86':4]
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.example.SanAngeles'

--- a/san-angeles/build.gradle
+++ b/san-angeles/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/san-angeles/gradle/wrapper/gradle-wrapper.properties
+++ b/san-angeles/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/san-angeles/settings.gradle
+++ b/san-angeles/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'

--- a/sensor-graph/accelerometer/build.gradle
+++ b/sensor-graph/accelerometer/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.android.accelerometergraph'

--- a/sensor-graph/build.gradle
+++ b/sensor-graph/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/sensor-graph/gradle/wrapper/gradle-wrapper.properties
+++ b/sensor-graph/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sensor-graph/settings.gradle
+++ b/sensor-graph/settings.gradle
@@ -1,2 +1,16 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include 'accelerometer'
 

--- a/teapots/build.gradle
+++ b/teapots/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/teapots/choreographer-30fps/build.gradle
+++ b/teapots/choreographer-30fps/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 30
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.sample.choreographer'

--- a/teapots/classic-teapot/build.gradle
+++ b/teapots/classic-teapot/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 30
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId = 'com.sample.teapot'

--- a/teapots/gradle/wrapper/gradle-wrapper.properties
+++ b/teapots/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/teapots/image-decoder/build.gradle
+++ b/teapots/image-decoder/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 30
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId = 'com.sample.imagedecoder'

--- a/teapots/more-teapots/build.gradle
+++ b/teapots/more-teapots/build.gradle
@@ -1,9 +1,10 @@
-apply plugin: 'com.android.application'
-
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 30
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId  'com.sample.moreteapots'

--- a/teapots/settings.gradle
+++ b/teapots/settings.gradle
@@ -1,3 +1,17 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':classic-teapot', ':more-teapots',
         ':choreographer-30fps', ':textured-teapot',
 	':image-decoder'

--- a/teapots/textured-teapot/build.gradle
+++ b/teapots/textured-teapot/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 30
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId = 'com.sample.texturedteapot'

--- a/webp/build.gradle
+++ b/webp/build.gradle
@@ -1,17 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    repositories {
-       google()
-       mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-    }
+plugins {
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/webp/gradle/wrapper/gradle-wrapper.properties
+++ b/webp/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/webp/settings.gradle
+++ b/webp/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':view'

--- a/webp/view/build.gradle
+++ b/webp/view/build.gradle
@@ -1,8 +1,10 @@
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+}
 
 android {
-    compileSdkVersion 29
-    ndkVersion '22.1.7171670'
+    compileSdk 33
+    ndkVersion '25.1.8937393'
 
     defaultConfig {
         applicationId 'com.example.webp_view'


### PR DESCRIPTION
settings.gradle:
* Add pluginManagement and dependencyResolutionManagement stanzas.

build.gradle:
* Remove declaration of repositories and dependencies, since this goes in settings.gradle
* Use Kotlin version 1.7.10
* Use AGP version 7.3.0

app/build.gradle:
* Use `plugins { id 'foo' }` instead `apply plugin: 'foo'`
* Compile all samples with the latest version of the SDK (33) and NDK (25.1.8937393).
* Remove kotlin-android-extensions

Furthermore:
* In CI build script, make detection of debug mode work on MacOS.
* Uncomment webp in CI build script.
* Add missing projects to CI build script (display-p3, hello-oboe, native-midi, prefab/prefab-dependency)
* Update gradle version to 7.4
* Update hello-oboe and prefab-dependency to use view binding.
* Update native-midi to eliminate compiler warning.