### PR TITLE
Fix lint errors for gles3jni.

### DIFF
--- a/gles3jni/app/build.gradle
+++ b/gles3jni/app/build.gradle
@@ -13,7 +13,7 @@ android {
     defaultConfig {
         applicationId 'com.android.gles3jni'
         minSdkVersion "${platformVersion}"
-        targetSdkVersion 28
+        targetSdkVersion 33
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_STL=c++_static'
@@ -33,4 +33,5 @@ android {
             path 'src/main/cpp/CMakeLists.txt'
         }
     }
+    namespace 'com.android.gles3jni'
 }

--- a/gles3jni/app/src/main/AndroidManifest.xml
+++ b/gles3jni/app/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
      limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.android.gles3jni">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-feature android:glEsVersion="0x00030000"/>
   <application
       android:allowBackup="false"
@@ -25,7 +24,8 @@
     <activity android:name="GLES3JNIActivity"
               android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
               android:launchMode="singleTask"
-              android:configChanges="orientation|keyboardHidden">
+              android:configChanges="orientation|keyboardHidden"
+        android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/other-builds/ndkbuild/gles3jni/app/AndroidManifest.xml
+++ b/other-builds/ndkbuild/gles3jni/app/AndroidManifest.xml
@@ -14,8 +14,7 @@
      limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.android.gles3jni">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
             android:label="@string/gles3jni_activity">
         <activity android:name="GLES3JNIActivity"

--- a/other-builds/ndkbuild/gles3jni/app/build.gradle
+++ b/other-builds/ndkbuild/gles3jni/app/build.gradle
@@ -20,7 +20,7 @@ android {
     defaultConfig {
         applicationId 'com.android.gles3jni'
         minSdkVersion 18
-        targetSdkVersion 28
+        targetSdkVersion 33
     }
     sourceSets {
         main {
@@ -41,6 +41,7 @@ android {
             path 'Android.mk'
         }
     }
+    namespace 'com.android.gles3jni'
 }
 
 


### PR DESCRIPTION
`./gradlew lint` reports no issues.