### PR TITLE
Fix lint errors for native-media.

### DIFF
--- a/native-media/app/build.gradle
+++ b/native-media/app/build.gradle
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         applicationId 'com.example.nativemedia'
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 33
     }
     buildTypes {
         release {
@@ -27,4 +27,5 @@ android {
     androidResources {
         noCompress 'ts'
     }
+    namespace 'com.example.nativemedia'
 }

--- a/native-media/app/src/main/AndroidManifest.xml
+++ b/native-media/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.example.nativemedia">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-feature android:glEsVersion="0x00020000" />
   <!-- INTERNET is needed to use a URI-based media player, depending on the URI -->
   <uses-permission android:name="android.permission.INTERNET"></uses-permission>
@@ -9,7 +8,8 @@
                android:icon="@mipmap/ic_launcher"
                android:label="@string/app_name">
     <activity android:name=".NativeMedia"
-              android:label="@string/app_name">
+              android:label="@string/app_name"
+        android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />

--- a/other-builds/ndkbuild/native-media/app/build.gradle
+++ b/other-builds/ndkbuild/native-media/app/build.gradle
@@ -13,7 +13,7 @@ android {
      defaultConfig {
         applicationId 'com.example.nativemedia'
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 33
      }
      sourceSets {
         main {
@@ -38,4 +38,5 @@ android {
     androidResources {
         noCompress 'ts'
     }
+    namespace 'com.example.nativemedia'
 }


### PR DESCRIPTION
`./gradlew lint` reports no issues.