### PR TITLE
Fix lint errors for native-midi.

### DIFF
--- a/native-midi/app/build.gradle
+++ b/native-midi/app/build.gradle
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         applicationId "com.example.nativemidi"
         minSdkVersion 29
-        targetSdkVersion 29
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         externalNativeBuild {
@@ -32,6 +32,7 @@ android {
             path "src/main/cpp/CMakeLists.txt"
         }
     }
+    namespace 'com.example.nativemidi'
 }
 
 dependencies {

--- a/native-midi/app/src/main/AndroidManifest.xml
+++ b/native-midi/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.nativemidi">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"
@@ -11,7 +10,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
`./gradlew lint` reports no issues.