### PR TITLE
Fix lint errors for curl-ssl.

### DIFF
--- a/prefab/curl-ssl/app/build.gradle
+++ b/prefab/curl-ssl/app/build.gradle
@@ -25,7 +25,7 @@ android {
     defaultConfig {
         applicationId "com.example.curlssl"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 
@@ -57,13 +57,14 @@ android {
         }
     }
     buildFeatures.prefab = true
+    namespace 'com.example.curlssl'
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.10"
-    implementation 'com.android.support:appcompat-v7:30.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation "com.android.ndk.thirdparty:curl:7.79.1-beta-1"
     implementation "com.android.ndk.thirdparty:jsoncpp:1.9.5-beta-1"
     implementation "com.android.ndk.thirdparty:openssl:1.1.1l-beta-1"

--- a/prefab/curl-ssl/app/src/main/AndroidManifest.xml
+++ b/prefab/curl-ssl/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.example.curlssl">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -11,7 +10,8 @@
             android:roundIcon="@mipmap/ic_launcher_round"
             android:supportsRtl="true"
             android:theme="@style/AppTheme">
-        <activity android:name="com.example.curlssl.MainActivity">
+        <activity android:name="com.example.curlssl.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 


### PR DESCRIPTION
`./gradlew lint` reports no issues.