### PR TITLE
Fix lint errors for prefab-publishing.

### DIFF
--- a/prefab/prefab-publishing/mylibrary/build.gradle
+++ b/prefab/prefab-publishing/mylibrary/build.gradle
@@ -24,7 +24,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 30
+        targetSdkVersion 33
 
         externalNativeBuild {
             cmake {


### PR DESCRIPTION
`./gradlew lint` reports no issues.