### PR TITLE
Update samples in Android Studio.

### DIFF
--- a/camera/.google/packaging.yaml
+++ b/camera/.google/packaging.yaml
@@ -3,5 +3,5 @@ technologies: [Android, NDK]
 categories:   [NDK]
 languages:    [C++, Java]
 solutions:    [Mobile]
-github:       googlesamples/android-ndk
+github:       android/ndk-samples
 license:      apache2

--- a/exceptions/.google/packaging.yaml
+++ b/exceptions/.google/packaging.yaml
@@ -3,5 +3,5 @@ technologies: [Android, NDK]
 categories:   [NDK]
 languages:    [C++, Java]
 solutions:    [Mobile]
-github:       googlesamples/android-ndk
+github:       android/ndk-samples
 license:      apache2

--- a/native-codec/.google/packaging.yaml
+++ b/native-codec/.google/packaging.yaml
@@ -1,0 +1,7 @@
+status:       PUBLISHED
+technologies: [Android, NDK]
+categories:   [NDK]
+languages:    [C++, Java]
+solutions:    [Mobile]
+github:       android/ndk-samples
+license:      apache2

--- a/native-media/.google/packaging.yaml
+++ b/native-media/.google/packaging.yaml
@@ -1,0 +1,7 @@
+status:       PUBLISHED
+technologies: [Android, NDK]
+categories:   [NDK]
+languages:    [C++, Java]
+solutions:    [Mobile]
+github:       android/ndk-samples
+license:      apache2

--- a/unit-test/.google/packaging.yaml
+++ b/unit-test/.google/packaging.yaml
@@ -1,0 +1,7 @@
+status:       PUBLISHED
+technologies: [Android, NDK]
+categories:   [NDK]
+languages:    [C++, Java]
+solutions:    [Mobile]
+github:       android/ndk-samples
+license:      apache2


### PR DESCRIPTION
Remove the following from Android Studio, since they use deprecated APIs: audio-echo, native-audio.
Add the following samples to Android Studio: camera, exceptions, native-audio, native-codec, native-media, unit-test.