### PR TITLE
Remove redundant dex packaging option

### DIFF
--- a/sanitizers/app/build.gradle
+++ b/sanitizers/app/build.gradle
@@ -66,11 +66,6 @@ android {
         viewBinding true
     }
 }
-androidComponents {
-    onVariants(selector().withBuildType("asan"), {
-        packaging.dex.useLegacyPackaging.set(true)
-    })
-}
 
 dependencies {
 


### PR DESCRIPTION
The correct option is jniLibs packaging option, but that's not needed because it's already the default for debug builds.