### PR TITLE
Remove fragile gradle parsing.

### DIFF
--- a/.ci_tools/setup_env.sh
+++ b/.ci_tools/setup_env.sh
@@ -10,7 +10,9 @@ for version in $(find . -name build.gradle | xargs grep -h compileSdk | sort | u
     echo y | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-${version}"
 done
 
-for version in $(find . -name build.gradle | xargs grep -h ndkVersion | sort | uniq | cut -d \' -f 2); do
+# TODO: We shouldn't use so many versions, especially not unsupported ones.
+# Get each sample onto a new version of AGP and just let the defaults drive.
+for version in 23.1.7779620 25.1.8937393 25.2.9519653; do
     echo y | $ANDROID_HOME/tools/bin/sdkmanager "ndk;${version}"
 done
 


### PR DESCRIPTION
My PGO sample broke this because it uses double quotes. Rather than fix the "parser", just explicitly list the versions we use here. Auto-detection is nice if we *want* to have a lot of versions supported, but we don't.