### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/native-activity/app/src/main/AndroidManifest.xml
+++ b/native-activity/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- BEGIN_INCLUDE(manifest) -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:versionCode="1"
           android:versionName="1.0">
 
@@ -26,6 +27,9 @@
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
     </activity>
+    <provider android:name="androidx.startup.InitializationProvider"
+              android:authorities="${applicationId}.androidx-startup"
+              tools:node="remove" />
   </application>
 
 </manifest>


### PR DESCRIPTION
Disable automatic initialisation for all components and dependencies otherwise the following exception is generated during application start-up.

java.lang.RuntimeException: Unable to get provider androidx.startup.InitializationProvider