### PR TITLE
Sanitizer: Set useLegacyPackaging for asan

### DIFF
--- a/sanitizers/app/build.gradle
+++ b/sanitizers/app/build.gradle
@@ -37,6 +37,12 @@ android {
         asan {
             initWith debug
             debuggable true
+            compileSdk 27
+            packagingOptions {
+                jniLibs {
+                    useLegacyPackaging true
+                }
+            }
             externalNativeBuild {
                 cmake {
                     arguments "-DANDROID_ARM_MODE=arm", "-DANDROID_STL=c++_shared", "-DSANITIZE=asan"

--- a/sanitizers/app/build.gradle
+++ b/sanitizers/app/build.gradle
@@ -10,6 +10,8 @@ android {
 
     defaultConfig {
         applicationId "com.example.sanitizers"
+        // If you raise minSdk to 23 or higher, make sure you've read the note
+        // below about useLegacyPackaging.
         minSdk 21
         targetSdk 32
         versionCode 1
@@ -39,6 +41,17 @@ android {
             debuggable true
             packagingOptions {
                 jniLibs {
+                    // Without legacy packaging, the Android package manager
+                    // will not extract the libraries from the APK, and the app
+                    // will instead load them directly from the APK. That saves
+                    // space on disk so is generally preferable, but ASan
+                    // doesn't work in that configuration, so we need to
+                    // opt-out of the new behavior.
+                    //
+                    // Note that this won't actually do anything to the sample
+                    // in its default configuration. The sample uses minSdk 21,
+                    // and legacy packaging is the default for all builds below
+                    // minSdk 23.
                     useLegacyPackaging true
                 }
             }

--- a/sanitizers/app/build.gradle
+++ b/sanitizers/app/build.gradle
@@ -37,7 +37,6 @@ android {
         asan {
             initWith debug
             debuggable true
-            compileSdk 27
             packagingOptions {
                 jniLibs {
                     useLegacyPackaging true


### PR DESCRIPTION
[Why]
Property useLegacyPackaging determin whether to use the legacy convention of compressing all .so files in the APK. If null, .so files will be uncompressed and page-aligned when minSdk >= 23. Otherwise, it failed with "INSTALL_FAILED_INVALID_APK: Failed to extract native libraries, res=-2" when minSdk >= 23.
And wrap.sh is only available for API level 27 and above.

[How]
Set useLegacyPackaging to true.
Set compileSdk to 27.

[Reference]
https://developer.android.com/ndk/guides/asan