### PR TITLE
Use setup-android to make sdkmanager available.

### DIFF
--- a/.ci_tools/setup_env.sh
+++ b/.ci_tools/setup_env.sh
@@ -7,12 +7,12 @@ if [ -f ~/.android/repositories.cfg ]; then
 fi
 
 for version in $(find . -name build.gradle | xargs grep -h compileSdk | sort | uniq | grep -o '[0-9]\+ *$'); do
-    echo y | $ANDROID_HOME/tools/bin/sdkmanager "platforms;android-${version}"
+    echo y | sdkmanager "platforms;android-${version}"
 done
 
 for version in $(find . -name build.gradle | xargs grep -h ndkVersion | sort | uniq | cut -d \' -f 2); do
-    echo y | $ANDROID_HOME/tools/bin/sdkmanager "ndk;${version}"
+    echo y | sdkmanager "ndk;${version}"
 done
 
-echo y | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "cmake;3.18.1"
-echo y | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "cmake;3.22.1"
+echo y | sdkmanager "cmake;3.18.1"
+echo y | sdkmanager "cmake;3.22.1"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,10 @@ jobs:
     - name: set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
+
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
 
     - uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
From the action's docs I don't think sdkmanager is actually unavailable, just obnoxious to find (seems the SDK moved that component to `cmdline-tools/$VERSION/bin`, and I've got no idea how to guess the version).

We could make broader use of this by moving the guts of `setup_env.sh` into build.yml, but to do that we'd have to remove the auto-detection of which NDK versions we need (though that's a bug anyway, AGP's supposed to be installing those for us). For now, just unbreak CI and we can deal with that later if it's ever worth doing.