### PR TITLE
fix native-activity ClassNotFoundException

### DIFF
--- a/native-activity/app/build.gradle
+++ b/native-activity/app/build.gradle
@@ -33,6 +33,4 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 }

--- a/native-activity/app/src/main/AndroidManifest.xml
+++ b/native-activity/app/src/main/AndroidManifest.xml
@@ -4,13 +4,11 @@
     android:versionCode="1"
           android:versionName="1.0">
 
-  <!-- This .apk has no Java code itself, so set hasCode to false. -->
   <application
       android:allowBackup="false"
       android:fullBackupContent="false"
       android:icon="@mipmap/ic_launcher"
-      android:label="@string/app_name"
-      android:hasCode="false">
+      android:label="@string/app_name">
 
     <!-- Our activity is the built-in NativeActivity framework class.
          This will take care of integrating with our NDK code. -->


### PR DESCRIPTION
fix issue https://github.com/android/ndk-samples/issues/929

why?
Library 'androidx.appcompat:appcompat:1.5.1' merged 'InitializationProvider' to final AndroidManifest.xml，and it also add InitializationProvider.class to final apk.
but android:hasCode="false" make this apk is pure native apk, so InitializationProvider.class doesn't work. we can clearly see the crash info DexPathList is empty.

Didn't find class "androidx.startup.InitializationProvider" on path: DexPathList[[],nativeLibraryDirectories

so AndroidManifest.xml has InitializationProvider info, but dex doesn't. that's why we get ClassNotFoundException.

there are two solutions.

remove useless library 'androidx.appcompat:appcompat:1.5.1', Neither AndroidManifest.xml nor dex have InitializationProvider info
remove android:hasCode="false", make dex work well
this pr remove useless library, and also remove android:hasCode="false" to avoid someone stuck in this problem again.
this is just sample, so I think it's ok.