### PR TITLE
Move sensor handling to a callback.

### DIFF
--- a/native-activity/app/build.gradle
+++ b/native-activity/app/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId = 'com.example.native_activity'
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 34
         externalNativeBuild {
             cmake {

--- a/native-activity/app/src/main/cpp/main.cpp
+++ b/native-activity/app/src/main/cpp/main.cpp
@@ -30,10 +30,13 @@
 #include <initializer_list>
 #include <memory>
 
-#define LOGI(...) \
-  ((void)__android_log_print(ANDROID_LOG_INFO, "native-activity", __VA_ARGS__))
-#define LOGW(...) \
-  ((void)__android_log_print(ANDROID_LOG_WARN, "native-activity", __VA_ARGS__))
+#define LOG_TAG "native-activity"
+
+#define _LOG(priority, fmt, ...) \
+  ((void)__android_log_print((priority), (LOG_TAG), (fmt)__VA_OPT__(, ) __VA_ARGS__))
+
+#define LOGW(fmt, ...) _LOG(ANDROID_LOG_WARN, (fmt)__VA_OPT__(, ) __VA_ARGS__)
+#define LOGI(fmt, ...) _LOG(ANDROID_LOG_INFO, (fmt)__VA_OPT__(, ) __VA_ARGS__)
 
 /**
  * Our saved state data.

--- a/native-activity/app/src/main/cpp/main.cpp
+++ b/native-activity/app/src/main/cpp/main.cpp
@@ -269,50 +269,6 @@ static void engine_handle_cmd(struct android_app* app, int32_t cmd) {
   }
 }
 
-/*
- * AcquireASensorManagerInstance(void)
- *    Workaround ASensorManager_getInstance() deprecation false alarm
- *    for Android-N and before, when compiling with NDK-r15
- */
-#include <dlfcn.h>
-ASensorManager* AcquireASensorManagerInstance(android_app* app) {
-  if (!app) return nullptr;
-
-  typedef ASensorManager* (*PF_GETINSTANCEFORPACKAGE)(const char* name);
-  void* androidHandle = dlopen("libandroid.so", RTLD_NOW);
-  auto getInstanceForPackageFunc = (PF_GETINSTANCEFORPACKAGE)dlsym(
-      androidHandle, "ASensorManager_getInstanceForPackage");
-  if (getInstanceForPackageFunc) {
-    JNIEnv* env = nullptr;
-    app->activity->vm->AttachCurrentThread(&env, nullptr);
-
-    jclass android_content_Context = env->GetObjectClass(app->activity->clazz);
-    jmethodID midGetPackageName = env->GetMethodID(
-        android_content_Context, "getPackageName", "()Ljava/lang/String;");
-    auto packageName =
-        (jstring)env->CallObjectMethod(app->activity->clazz, midGetPackageName);
-
-    const char* nativePackageName =
-        env->GetStringUTFChars(packageName, nullptr);
-    ASensorManager* mgr = getInstanceForPackageFunc(nativePackageName);
-    env->ReleaseStringUTFChars(packageName, nativePackageName);
-    app->activity->vm->DetachCurrentThread();
-    if (mgr) {
-      dlclose(androidHandle);
-      return mgr;
-    }
-  }
-
-  typedef ASensorManager* (*PF_GETINSTANCE)();
-  auto getInstanceFunc =
-      (PF_GETINSTANCE)dlsym(androidHandle, "ASensorManager_getInstance");
-  // by all means at this point, ASensorManager_getInstance should be available
-  assert(getInstanceFunc);
-  dlclose(androidHandle);
-
-  return getInstanceFunc();
-}
-
 /**
  * This is the main entry point of a native application that is using
  * android_native_app_glue.  It runs in its own thread, with its own
@@ -328,7 +284,7 @@ void android_main(struct android_app* state) {
   engine.app = state;
 
   // Prepare to monitor accelerometer
-  engine.sensorManager = AcquireASensorManagerInstance(state);
+  engine.sensorManager = ASensorManager_getInstance();
   engine.accelerometerSensor = ASensorManager_getDefaultSensor(
       engine.sensorManager, ASENSOR_TYPE_ACCELEROMETER);
   engine.sensorEventQueue = ASensorManager_createEventQueue(

--- a/other-builds/ndkbuild/native-activity/app/build.gradle
+++ b/other-builds/ndkbuild/native-activity/app/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId = 'com.example.native_activity'
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 33
     }
     sourceSets {


### PR DESCRIPTION
The apparent change in `minSdkVersion` here isn't actually changing much. The NDK hasn't supported ICS in a long time, and 21 is the minimum for modern NDKs (though I think this sample is still using an NDK that supports 19, it won't soon). The raise is needed for `android_set_abort_message`.