### PR TITLE
Switch to buildFeatures for BuildConfig flag.

### DIFF
--- a/native-audio/app/build.gradle
+++ b/native-audio/app/build.gradle
@@ -25,6 +25,10 @@ android {
         }
     }
     namespace 'com.example.nativeaudio'
+
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies {

--- a/native-audio/gradle.properties
+++ b/native-audio/gradle.properties
@@ -1,4 +1,3 @@
-android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false


### PR DESCRIPTION
gradle.properties, afaict, can't be applied per module. Once these are all in one giant project we want to apply this property at a finer scope than globally, so move it to buildFeatures, which are preferred anyway.