### PR TITLE
Cover ubsan libraries with gitignore.

### DIFF
--- a/sanitizers/app/.gitignore
+++ b/sanitizers/app/.gitignore
@@ -1,1 +1,4 @@
 /build
+
+# These are installed by the cmake build.
+libclang_rt.*.so

--- a/sanitizers/app/src/asan/jniLibs/.gitignore
+++ b/sanitizers/app/src/asan/jniLibs/.gitignore
@@ -1,2 +1,0 @@
-# These are installed by the cmake build.
-libclang_rt.asan-*-android.so


### PR DESCRIPTION
This was previously only scoped to ASan. Move it up to the module directory so it covers all variants.