### PR TITLE
Update Kotlin to match the rest of the samples.

### DIFF
--- a/exceptions/build.gradle
+++ b/exceptions/build.gradle
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.application' version '8.4.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.20' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.21' apply false
 }


### PR DESCRIPTION
Not actually a proper upgrade, but the other samples that use Kotlin are all on 1.7.21.