### PR TITLE
Downgrade hello-vulkan's kotlin to match the other samples.

### DIFF
--- a/hello-vulkan/app/build.gradle
+++ b/hello-vulkan/app/build.gradle
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
 
 android {
     compileSdk 33

--- a/hello-vulkan/app/build.gradle
+++ b/hello-vulkan/app/build.gradle
@@ -67,7 +67,6 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.10.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.games:games-activity:2.1.0-alpha01'
 }

--- a/hello-vulkan/build.gradle
+++ b/hello-vulkan/build.gradle
@@ -19,5 +19,5 @@
 
 plugins {
     id 'com.android.application' version '8.4.0' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.20' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.21' apply false
 }

--- a/hello-vulkan/build.gradle
+++ b/hello-vulkan/build.gradle
@@ -17,12 +17,7 @@
 // Top-level build file where you can add configuration options
 // common to all sub-projects/modules.
 
-buildscript {
-    ext {
-        kotlin_version = '1.8.20'
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.4.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
+plugins {
+    id 'com.android.application' version '8.4.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.20' apply false
 }

--- a/hello-vulkan/build.gradle
+++ b/hello-vulkan/build.gradle
@@ -21,19 +21,8 @@ buildscript {
     ext {
         kotlin_version = '1.8.20'
     }
-    repositories {
-       google()
-       mavenCentral()
-    }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.4.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
     }
 }

--- a/hello-vulkan/settings.gradle
+++ b/hello-vulkan/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'


### PR DESCRIPTION
Combining all the samples into one project means they have to all use the same Kotlin plugin version, which is 1.7.21 for all the others.