### PR TITLE
Migrate a kotlin sample to the convention plugin.

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -19,6 +19,7 @@ tasks.withType<KotlinCompile>().configureEach {
 
 dependencies {
     compileOnly(libs.android.gradlePlugin)
+    compileOnly(libs.kotlin.gradlePlugin)
 }
 
 gradlePlugin {
@@ -26,6 +27,10 @@ gradlePlugin {
         register("androidApplication") {
             id = "ndksamples.android.application"
             implementationClass = "com.android.ndk.samples.buildlogic.AndroidApplicationConventionPlugin"
+        }
+        register("kotlinAndroid") {
+            id = "ndksamples.android.kotlin"
+            implementationClass = "com.android.ndk.samples.buildlogic.KotlinConventionPlugin"
         }
     }
 }

--- a/build-logic/src/main/java/com/android/ndk/samples/buildlogic/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/src/main/java/com/android/ndk/samples/buildlogic/AndroidApplicationConventionPlugin.kt
@@ -20,6 +20,10 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                     minSdk = Versions.MIN_SDK
                     targetSdk = Versions.TARGET_SDK
                 }
+                compileOptions {
+                    sourceCompatibility = Versions.JAVA
+                    targetCompatibility = Versions.JAVA
+                }
             }
         }
     }

--- a/build-logic/src/main/java/com/android/ndk/samples/buildlogic/KotlinConventionPlugin.kt
+++ b/build-logic/src/main/java/com/android/ndk/samples/buildlogic/KotlinConventionPlugin.kt
@@ -1,0 +1,27 @@
+package com.android.ndk.samples.buildlogic
+
+import com.android.build.api.dsl.ApplicationExtension
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+class KotlinConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("org.jetbrains.kotlin.android")
+            }
+
+            extensions.configure<ApplicationExtension> {
+                tasks.withType<KotlinCompile>().configureEach {
+                    kotlinOptions {
+                        jvmTarget = Versions.JAVA.toString()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build-logic/src/main/java/com/android/ndk/samples/buildlogic/Versions.kt
+++ b/build-logic/src/main/java/com/android/ndk/samples/buildlogic/Versions.kt
@@ -1,8 +1,11 @@
 package com.android.ndk.samples.buildlogic
 
+import org.gradle.api.JavaVersion
+
 object Versions {
     const val COMPILE_SDK = 34
     const val TARGET_SDK = 34
     const val MIN_SDK = 21
     const val NDK = "26.3.11579264" // r26d
+    val JAVA = JavaVersion.VERSION_1_8
 }

--- a/exceptions/app/build.gradle
+++ b/exceptions/app/build.gradle
@@ -1,52 +1,30 @@
 plugins {
-    id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
+    id "ndksamples.android.application"
+    id "ndksamples.android.kotlin"
 }
 
 android {
     namespace 'com.example.exceptions'
-    compileSdk 33
 
     defaultConfig {
         applicationId "com.example.exceptions"
-        minSdk 21
-        targetSdk 33
         versionCode 1
         versionName "1.0"
-
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-        }
-    }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
     externalNativeBuild {
         cmake {
             path file('src/main/cpp/CMakeLists.txt')
         }
     }
+
     buildFeatures {
         viewBinding true
     }
 }
 
 dependencies {
-
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.5.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation libs.appcompat
+    implementation libs.material
+    implementation libs.androidx.constraintlayout
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitV
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 
 # build-logic dependencies
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ kotlin = "1.7.21"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
+androidxConstraintLayout = "2.1.4"
 appcompat = "1.6.1"
 material = "1.12.0"
 jetbrainsKotlinJvm = "1.7.21"
@@ -12,6 +13,7 @@ jetbrainsKotlinJvm = "1.7.21"
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidxConstraintLayout" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
Needs another convention for Kotlin stuff to keep the Java/Kotlin versions in sync.

Depends on https://github.com/android/ndk-samples/pull/1030.