### PR TITLE
Move the fast part of the "build" sooner.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,12 @@ jobs:
       with:
         java-version: 17
 
+    - uses: pre-commit/action@v3.0.0
+
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
 
     - name: build samples
       run: |
         ./gradlew build
-
-    - uses: pre-commit/action@v3.0.0
 


### PR DESCRIPTION
I'm tired of waiting for the build to finish only to learn that my markdown isn't markdowny enough.