### PR TITLE
Remove no-op build option.

### DIFF
--- a/orderfile/app/build.gradle
+++ b/orderfile/app/build.gradle
@@ -38,7 +38,6 @@ android {
     externalNativeBuild {
         cmake {
             path file('src/main/cpp/CMakeLists.txt')
-            version '3.22.1'
         }
     }
     buildFeatures {


### PR DESCRIPTION
AGP uses the latest available by default, which is what we want.