### PR TITLE
Stop downgrading CMake.

### DIFF
--- a/sanitizers/app/build.gradle
+++ b/sanitizers/app/build.gradle
@@ -92,7 +92,6 @@ android {
     externalNativeBuild {
         cmake {
             path file('src/main/cpp/CMakeLists.txt')
-            version '3.18.1'
         }
     }
     buildFeatures {


### PR DESCRIPTION
This might have been an upgrade when it was added, but AGP defaults to something newer now.