### PR TITLE
Disable mdformat check.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,3 @@ repos:
     hooks:
     -   id: check-xml
     -   id: check-yaml
--   repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.16
-    hooks:
-    -   id: mdformat
-        args: ["--wrap", "80"]
-        additional_dependencies:
-        - mdformat-gfm


### PR DESCRIPTION
mdformat is a jerk and wants to change the case of links. I'll be back to re-apply prettier if we think we need it.