### PR TITLE
camera:basic: fail if permissions are not granted

### DIFF
--- a/camera/basic/src/main/cpp/camera_ui.cpp
+++ b/camera/basic/src/main/cpp/camera_ui.cpp
@@ -115,9 +115,9 @@ void CameraEngine::OnPhotoTaken(const char *fileName) {
 void CameraEngine::OnCameraPermission(jboolean granted) {
   cameraGranted_ = (granted != JNI_FALSE);
 
-  if (cameraGranted_) {
-    OnAppInitWindow();
-  }
+  // TODO: Fail gracefully.
+  ASSERT(cameraGranted_, "required app permissions were not granted");
+  OnAppInitWindow();
 }
 
 /**


### PR DESCRIPTION
Pre-work for https://github.com/android/ndk-samples/issues/1031. For some reason the UI for the storage permission isn't shown whenever targetSdkVersion is 33+, and it's just returning a denial. This sample is badly structured such that if either permission isn't granted, the UI init will never run. The two permissions requests really ought to be decoupled (the viewfinder should still work even if I never try to save a photo), and the UI should tell the user why it failed. For now I'm just making it fail more violently, because the lack of any error or logging is what made this a multi-hour debugging experience instead of the now obvious problem.