### PR TITLE
Fix the build workflow to actually run on push.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: build
 
-on:
-  push:
-    branches: [ main develop ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
`[ main develop ]` is not a list of "main" and "develop", it's a list of "main develop". There is no branch named "main develop". This has been wrong since it was originally checked in a few years ago, so checks just have not been running on push.

The branch filtering is totally unnecessary. Just remove it.

This, it turns out, is the real reason that the badge shows "no status". It's right. This build has never run, so there is no status yet.