### PR TITLE
camera:basic: don't request WRITE_EXTERNAL_STORAGE

### DIFF
--- a/camera/basic/src/main/AndroidManifest.xml
+++ b/camera/basic/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
           android:versionName="1.0">
   <uses-feature android:name="android.hardware.camera" />
   <uses-permission android:name="android.permission.CAMERA" />
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <application
       android:allowBackup="false"
       android:fullBackupContent="false"

--- a/camera/basic/src/main/java/com/sample/camera/basic/CameraActivity.java
+++ b/camera/basic/src/main/java/com/sample/camera/basic/CameraActivity.java
@@ -188,23 +188,15 @@ public class CameraActivity extends NativeActivity
             Log.e(DBG_TAG, "Found legacy camera Device, this sample needs camera2 device");
             return;
         }
-        String[] accessPermissions = new String[] {
-            Manifest.permission.CAMERA,
-            Manifest.permission.WRITE_EXTERNAL_STORAGE
-        };
-        boolean needRequire  = false;
-        for(String access : accessPermissions) {
-           int curPermission = ActivityCompat.checkSelfPermission(this, access);
-           if(curPermission != PackageManager.PERMISSION_GRANTED) {
-               needRequire = true;
-               break;
-           }
-        }
-        if (needRequire) {
+        if (ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.CAMERA
+        ) != PackageManager.PERMISSION_GRANTED) {
             ActivityCompat.requestPermissions(
                     this,
-                    accessPermissions,
-                    PERMISSION_REQUEST_CODE_CAMERA);
+                    new String[]{Manifest.permission.CAMERA},
+                    PERMISSION_REQUEST_CODE_CAMERA
+            );
             return;
         }
         notifyCameraPermission(true);


### PR DESCRIPTION
Not needed for writing to the SD card since KitKat, and the permission is auto-denied for targetSdkVersion 33+:
https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE

This isn't really the right way to do this though. We're supposed to do https://developer.android.com/training/data-storage/use-cases?utm_source=lint&utm_medium=lint&utm_campaign=lint#capture-image-media

Fixes https://github.com/android/ndk-samples/issues/1031