### PR TITLE
camera:texture-view: remove unused permission

### DIFF
--- a/camera/texture-view/src/main/AndroidManifest.xml
+++ b/camera/texture-view/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
     android:versionName="1.0" >
 
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" />


### PR DESCRIPTION
This was probably copied from the other camera sample that supports saving images. This one does not, and even if it did, that permission hasn't been needed since KitKat anyway.