### PR TITLE
textured-teapot: remove dead code

### DIFF
--- a/teapots/textured-teapot/src/main/cpp/TeapotRenderer.cpp
+++ b/teapots/textured-teapot/src/main/cpp/TeapotRenderer.cpp
@@ -43,16 +43,8 @@ void TeapotRenderer::Init() {
   glFrontFace(GL_CCW);
 
   // Load shader
-  GLint type = GetTextureType();
-  if (type == GL_TEXTURE_CUBE_MAP) {
-    LoadShaders(&shader_param_, "Shaders/Cubemap.vsh", "Shaders/Cubemap.fsh");
-  } else if (type == GL_TEXTURE_2D) {
-    LoadShaders(&shader_param_, "Shaders/2DTexture.vsh",
-                "Shaders/2DTexture.fsh");
-  } else {
-    LoadShaders(&shader_param_, "Shaders/VS_ShaderPlain.vsh",
-                "Shaders/ShaderPlain.fsh");
-  }
+  LoadShaders(&shader_param_, "Shaders/Cubemap.vsh", "Shaders/Cubemap.fsh");
+
   // Create Index buffer
   num_indices_ = sizeof(teapotIndices) / sizeof(teapotIndices[0]);
   glGenBuffers(1, &ibo_);

--- a/teapots/textured-teapot/src/main/cpp/TeapotRenderer.h
+++ b/teapots/textured-teapot/src/main/cpp/TeapotRenderer.h
@@ -92,7 +92,6 @@ class TeapotRenderer {
   TeapotRenderer();
   virtual ~TeapotRenderer();
   virtual void Init(AAssetManager* amgr) = 0;
-  virtual GLint GetTextureType(void) = 0;
   virtual void Render();
   void Update(float dTime);
   bool Bind(ndk_helper::TapCamera* camera);

--- a/teapots/textured-teapot/src/main/cpp/Texture.cpp
+++ b/teapots/textured-teapot/src/main/cpp/Texture.cpp
@@ -75,22 +75,12 @@ Texture::~Texture() {}
 /**
  * Create Texture Object
  * @param texFiles holds the texture file name(s) under APK's assets
- * @param type should be one (GL_TEXTURE_2D / GL_TEXTURE_CUBE_MAP)
  * @param assetManager is used to open texture files inside assets
  * @return is the newly created Texture Object
  */
-Texture* Texture::Create(GLuint type, std::vector<std::string>& texFiles,
+Texture* Texture::Create(std::vector<std::string>& texFiles,
                          AAssetManager* assetManager) {
-  if (type == GL_TEXTURE_2D) {
-    return dynamic_cast<Texture*>(new Texture2d(texFiles[0], assetManager));
-  } else if (type == GL_TEXTURE_CUBE_MAP) {
-    return dynamic_cast<Texture*>(new TextureCubemap(texFiles, assetManager));
-  }
-
-  LOGE("Unknow texture type %x to created", type);
-  LOGE("Supported Texture Types: %s", supportedTextureTypes.c_str());
-  assert(false);
-  return nullptr;
+  return new TextureCubemap(texFiles, assetManager);
 }
 
 void Texture::Delete(Texture* obj) {

--- a/teapots/textured-teapot/src/main/cpp/Texture.h
+++ b/teapots/textured-teapot/src/main/cpp/Texture.h
@@ -43,14 +43,13 @@ class Texture {
  public:
   /**
    *   Create a texture object
-   * @param type  should be GL_TEXTURE_2D / GL_TEXTURE_CUBE_MAP
    * @param texFiles holds image file names under APK/assets.
    *     2d texture uses the very first image texFiles[0]
    *     cube map needs 6 (direction of +x, -x, +y, -y, +z, -z)
    * @param assetManager Java side assetManager object
    * @return newly created texture object, or nullptr in case of errors
    */
-  static Texture* Create(GLuint type, std::vector<std::string>& texFiles,
+  static Texture* Create(std::vector<std::string>& texFiles,
                          AAssetManager* assetManager);
   static void Delete(Texture* obj);
 

--- a/teapots/textured-teapot/src/main/cpp/TexturedTeapotRender.h
+++ b/teapots/textured-teapot/src/main/cpp/TexturedTeapotRender.h
@@ -32,13 +32,6 @@ class TexturedTeapotRender : public TeapotRenderer {
  public:
   TexturedTeapotRender();
   virtual ~TexturedTeapotRender();
-  // This is to decide which teapot type to render:
-  //   plain teapot
-  //   2D textured teapot
-  //   Cubemap textured teapot
-  // the rest of the code looks this function to decide
-  // what to render.
-  virtual GLint GetTextureType(void);
   virtual void Init(AAssetManager* amgr);
   virtual void Render();
   virtual void Unload();


### PR DESCRIPTION
Whoever wrote this wrote some general purpose texture and renderer classes... which they then copy pasted into each sample. This sample only ever uses a cubemap texture, so delete the other paths and remove the error handling code for a thing that will never happen.

The original intent was good, but it's pointless when the three teapots samples (classic, textured, and image-decoder) are three samples that don't share this "common" code. I suspect I'll merge the three at some point, but I don't really like how this particular interface was shaped anyway, so I'll probably rewrite that when I do.