### PR TITLE
Upgrade to NDK r27 RC 1.

### DIFF
--- a/build-logic/src/main/java/com/android/ndk/samples/buildlogic/Versions.kt
+++ b/build-logic/src/main/java/com/android/ndk/samples/buildlogic/Versions.kt
@@ -6,6 +6,6 @@ object Versions {
     const val COMPILE_SDK = 34
     const val TARGET_SDK = 34
     const val MIN_SDK = 21
-    const val NDK = "26.3.11579264" // r26d
+    const val NDK = "27.0.11902837-rc1" // r27 RC 1
     val JAVA = JavaVersion.VERSION_1_8
 }


### PR DESCRIPTION
I didn't want to do this with a beta, but I think it's reasonable for us to adopt the release candidates.