### PR TITLE
Fix .clang-format to not preserve bad format.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: Google
+DerivePointerAlignment: false


### PR DESCRIPTION
Deriving pointer alignment essentially makes this do nothing, since for whatever reason (fighting with Studio maybe?), for new files it's deriving the wrong style.