### PR TITLE
Update AppMidiManager.cpp

### DIFF
--- a/native-midi/app/src/main/cpp/AppMidiManager.cpp
+++ b/native-midi/app/src/main/cpp/AppMidiManager.cpp
@@ -206,6 +206,7 @@ void Java_com_example_nativemidi_AppMidiManager_startWritingMidi(
  */
 void Java_com_example_nativemidi_AppMidiManager_stopWritingMidi(JNIEnv*,
                                                                 jobject) {
+  AMidiInputPort_close(sMidiInputPort); //Close InputPort to make switching MidiDevices work!
   /*media_status_t status =*/AMidiDevice_release(sNativeSendDevice);
   sNativeSendDevice = NULL;
 }

--- a/native-midi/app/src/main/cpp/AppMidiManager.cpp
+++ b/native-midi/app/src/main/cpp/AppMidiManager.cpp
@@ -206,7 +206,10 @@ void Java_com_example_nativemidi_AppMidiManager_startWritingMidi(
  */
 void Java_com_example_nativemidi_AppMidiManager_stopWritingMidi(JNIEnv*,
                                                                 jobject) {
+  if (sMidiInputPort != nullptr) {
   AMidiInputPort_close(sMidiInputPort); //Close InputPort to make switching MidiDevices work!
+  sMidiInputPort = nullptr;
+  }
   /*media_status_t status =*/AMidiDevice_release(sNativeSendDevice);
   sNativeSendDevice = NULL;
 }


### PR DESCRIPTION
When switching MidiDevices the InputPort needs to be closed first, otherwise the new selected MidiDevice doesn't receive any Messages. This is at least the case on my android Device.

AMidiInputPort_close(sMidiInputPort);