### PR TITLE
Fix all missing project warnings.

### DIFF
--- a/bitmap-plasma/app/src/main/cpp/CMakeLists.txt
+++ b/bitmap-plasma/app/src/main/cpp/CMakeLists.txt
@@ -1,13 +1,14 @@
 cmake_minimum_required(VERSION 3.22.1)
+project(BitmapPlasma LANGUAGES C)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -Wno-unused-function")
 
-add_library(plasma SHARED
-            plasma.c)
+add_library(plasma SHARED plasma.c)
 
 # Include libraries needed for plasma lib
 target_link_libraries(plasma
-                      android
-                      jnigraphics
-                      log
-                      m)
+    android
+    jnigraphics
+    log
+    m
+)

--- a/camera/basic/src/main/cpp/CMakeLists.txt
+++ b/camera/basic/src/main/cpp/CMakeLists.txt
@@ -15,6 +15,7 @@
 #
 
 cmake_minimum_required(VERSION 3.22.1)
+project(CameraBasic LANGUAGES C CXX)
 
 set(CMAKE_VERBOSE_MAKEFILE on)
 set(COMMON_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../common)

--- a/camera/texture-view/src/main/cpp/CMakeLists.txt
+++ b/camera/texture-view/src/main/cpp/CMakeLists.txt
@@ -15,6 +15,7 @@
 #
 
 cmake_minimum_required(VERSION 3.22.1)
+project(CameraTextureView LANGUAGES CXX)
 
 set(CMAKE_VERBOSE_MAKEFILE on)
 set(COMMON_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../common)

--- a/endless-tunnel/app/src/main/cpp/CMakeLists.txt
+++ b/endless-tunnel/app/src/main/cpp/CMakeLists.txt
@@ -15,10 +15,12 @@
 #
 
 cmake_minimum_required(VERSION 3.22.1)
+project(EndlessTunnel LANGUAGES C CXX)
 
 # build native_app_glue as a static lib
 add_library(native_app_glue STATIC
-     ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
+    ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c
+)
 
 # Export ANativeActivity_onCreate(),
 # Refer to: https://github.com/android-ndk/ndk/issues/381.
@@ -34,43 +36,46 @@ add_subdirectory(glm)
 
 # now build app's shared lib
 add_library(game SHARED
-     android_main.cpp
-     anim.cpp
-     ascii_to_geom.cpp
-     dialog_scene.cpp
-     indexbuf.cpp
-     input_util.cpp
-     jni_util.cpp
-     native_engine.cpp
-     obstacle.cpp
-     obstacle_generator.cpp
-     our_shader.cpp
-     play_scene.cpp
-     scene.cpp
-     scene_manager.cpp
-     sfxman.cpp
-     shader.cpp
-     shape_renderer.cpp
-     tex_quad.cpp
-     text_renderer.cpp
-     texture.cpp
-     ui_scene.cpp
-     util.cpp
-     vertexbuf.cpp
-     welcome_scene.cpp)
+    android_main.cpp
+    anim.cpp
+    ascii_to_geom.cpp
+    dialog_scene.cpp
+    indexbuf.cpp
+    input_util.cpp
+    jni_util.cpp
+    native_engine.cpp
+    obstacle.cpp
+    obstacle_generator.cpp
+    our_shader.cpp
+    play_scene.cpp
+    scene.cpp
+    scene_manager.cpp
+    sfxman.cpp
+    shader.cpp
+    shape_renderer.cpp
+    tex_quad.cpp
+    text_renderer.cpp
+    texture.cpp
+    ui_scene.cpp
+    util.cpp
+    vertexbuf.cpp
+    welcome_scene.cpp
+)
 
 target_include_directories(game PRIVATE
-     ${CMAKE_CURRENT_SOURCE_DIR}
-     ${CMAKE_CURRENT_SOURCE_DIR}/data
-     ${ANDROID_NDK}/sources/android/native_app_glue)
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/data
+    ${ANDROID_NDK}/sources/android/native_app_glue
+)
 
 # add lib dependencies
 target_link_libraries(game
-     android
-     native_app_glue
-     atomic
-     EGL
-     GLESv2
-     glm
-     log
-     OpenSLES)
+    android
+    native_app_glue
+    atomic
+    EGL
+    GLESv2
+    glm
+    log
+    OpenSLES
+)

--- a/gles3jni/app/src/main/cpp/CMakeLists.txt
+++ b/gles3jni/app/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.22.1)
+project(Gles3Jni LANGUAGES C CXX)
+
 # set targetPlatform, will be passed in from gradle when this sample is completed
 # openGL Supportability
 # platform         status
@@ -22,27 +24,29 @@ cmake_minimum_required(VERSION 3.22.1)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fno-exceptions -Wall")
 if (${ANDROID_PLATFORM_LEVEL} LESS 12)
-  message(FATAL_ERROR "OpenGL 2 is not supported before API level 11 \
+    message(FATAL_ERROR "OpenGL 2 is not supported before API level 11 \
                       (currently using ${ANDROID_PLATFORM_LEVEL}).")
-  return()
+    return()
 elseif (${ANDROID_PLATFORM_LEVEL} LESS 18)
-  add_definitions("-DDYNAMIC_ES3")
-  set(GL3STUB_SRC gl3stub.c)
-  set(OPENGL_LIB GLESv2)
+    add_definitions("-DDYNAMIC_ES3")
+    set(GL3STUB_SRC gl3stub.c)
+    set(OPENGL_LIB GLESv2)
 else ()
-  set(OPENGL_LIB GLESv3)
+    set(OPENGL_LIB GLESv3)
 endif (${ANDROID_PLATFORM_LEVEL} LESS 12)
 
 add_library(gles3jni SHARED
-            ${GL3STUB_SRC}
-            gles3jni.cpp 
-            RendererES2.cpp
-            RendererES3.cpp)
+    ${GL3STUB_SRC}
+    gles3jni.cpp
+    RendererES2.cpp
+    RendererES3.cpp
+)
 
 # Include libraries needed for gles3jni lib
 target_link_libraries(gles3jni
-            ${OPENGL_LIB}
-            android
-            EGL
-            log
-            m)
+    ${OPENGL_LIB}
+    android
+    EGL
+    log
+    m
+)

--- a/hello-gl2/app/src/main/cpp/CMakeLists.txt
+++ b/hello-gl2/app/src/main/cpp/CMakeLists.txt
@@ -1,15 +1,16 @@
 cmake_minimum_required(VERSION 3.22.1)
+project(HelloGl2 LANGUAGES CXX)
 
 # now build app's shared lib
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
-add_library(gl2jni SHARED
-            gl_code.cpp)
+add_library(gl2jni SHARED gl_code.cpp)
 
 # add lib dependencies
 target_link_libraries(gl2jni
-                      android
-                      log 
-                      EGL
-                      GLESv2)
+    android
+    log
+    EGL
+    GLESv2
+)
 

--- a/hello-jniCallback/app/src/main/cpp/CMakeLists.txt
+++ b/hello-jniCallback/app/src/main/cpp/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 3.22.1)
+project(HelloJniCallback LANGUAGES C)
 
-add_library(hello-jnicallback SHARED
-            hello-jnicallback.c)
+add_library(hello-jnicallback SHARED hello-jnicallback.c)
 
 # Include libraries needed for hello-jnicallback lib
 target_link_libraries(hello-jnicallback
-                      android
-                      log)
+    android
+    log
+)

--- a/hello-libs/app/src/main/cpp/CMakeLists.txt
+++ b/hello-libs/app/src/main/cpp/CMakeLists.txt
@@ -16,6 +16,7 @@
 #
 
 cmake_minimum_required(VERSION 3.22.1)
+project(HelloLibs LANGUAGES CXX)
 
 # configure import libs
 set(distribution_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../distribution)
@@ -34,14 +35,17 @@ set_target_properties(lib_gperf PROPERTIES IMPORTED_LOCATION
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
 add_library(hello-libs SHARED
-            hello-libs.cpp)
+    hello-libs.cpp
+)
 
 target_include_directories(hello-libs PRIVATE
-                           ${distribution_DIR}/gmath/include
-                           ${distribution_DIR}/gperf/include)
+    ${distribution_DIR}/gmath/include
+    ${distribution_DIR}/gperf/include
+)
 
 target_link_libraries(hello-libs
-                      android
-                      lib_gmath
-                      lib_gperf
-                      log)
+    android
+    lib_gmath
+    lib_gperf
+    log
+)

--- a/hello-neon/app/src/main/cpp/CMakeLists.txt
+++ b/hello-neon/app/src/main/cpp/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required(VERSION 3.22.1)
+project(HelloNeon LANGUAGES C)
 
 # build cpufeatures as a static lib
 add_library(cpufeatures STATIC
-            ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c)
+    ${ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c
+)
 
 # build app's shared lib
 
@@ -13,12 +15,12 @@ add_library(cpufeatures STATIC
 # [This example only build for armeabi-v7a, x86 could be done the same way]
 #
 if (${ANDROID_ABI} STREQUAL "armeabi-v7a")
-  # make a list of neon files and add neon compiling flags to them
-  set(neon_SRCS helloneon-intrinsics.c)
+    # make a list of neon files and add neon compiling flags to them
+    set(neon_SRCS helloneon-intrinsics.c)
 
-  set_property(SOURCE ${neon_SRCS}
-               APPEND_STRING PROPERTY COMPILE_FLAGS " -mfpu=neon")
-  add_definitions("-DHAVE_NEON=1")
+    set_property(SOURCE ${neon_SRCS}
+        APPEND_STRING PROPERTY COMPILE_FLAGS " -mfpu=neon")
+    add_definitions("-DHAVE_NEON=1")
 elseif (${ANDROID_ABI} STREQUAL "x86")
     set(neon_SRCS helloneon-intrinsics.c)
     set_property(SOURCE ${neon_SRCS} APPEND_STRING PROPERTY COMPILE_FLAGS

--- a/native-activity/app/src/main/cpp/CMakeLists.txt
+++ b/native-activity/app/src/main/cpp/CMakeLists.txt
@@ -15,6 +15,7 @@
 #
 
 cmake_minimum_required(VERSION 3.22.1)
+project(NativeActivity LANGUAGES C CXX)
 
 # build native_app_glue as a static lib
 set(${CMAKE_C_FLAGS}, "${CMAKE_C_FLAGS}")

--- a/native-audio/app/src/main/cpp/CMakeLists.txt
+++ b/native-audio/app/src/main/cpp/CMakeLists.txt
@@ -1,12 +1,15 @@
 cmake_minimum_required(VERSION 3.22.1)
+project(NativeAudio LANGUAGES C)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
 add_library(native-audio-jni SHARED
-            native-audio-jni.c)
+    native-audio-jni.c
+)
 
 # Include libraries needed for native-audio-jni lib
 target_link_libraries(native-audio-jni
-                      android
-                      log
-                      OpenSLES)
+    android
+    log
+    OpenSLES
+)

--- a/native-media/app/src/main/cpp/CMakeLists.txt
+++ b/native-media/app/src/main/cpp/CMakeLists.txt
@@ -1,14 +1,17 @@
 cmake_minimum_required(VERSION 3.22.1)
+project(NativeMedia LANGUAGES C)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -UNDEBUG")
 
 add_library(native-media-jni SHARED
-            android_fopen.c
-            native-media-jni.c)
+    android_fopen.c
+    native-media-jni.c
+)
 
 # Include libraries needed for native-media-jni lib
 target_link_libraries(native-media-jni
-                      android
-                      log
-                      OpenMAXAL)
+    android
+    log
+    OpenMAXAL
+)
 

--- a/native-plasma/app/src/main/cpp/CMakeLists.txt
+++ b/native-plasma/app/src/main/cpp/CMakeLists.txt
@@ -15,6 +15,7 @@
 #
 
 cmake_minimum_required(VERSION 3.22.1)
+project(NativePlasma LANGUAGES C)
 
 # build native_app_glue as a static lib
 add_library(native_app_glue STATIC

--- a/nn-samples/basic/src/main/cpp/CMakeLists.txt
+++ b/nn-samples/basic/src/main/cpp/CMakeLists.txt
@@ -1,13 +1,15 @@
 cmake_minimum_required(VERSION 3.22.1)
+project(NnSamplesBasic LANGUAGES CXX)
 
 add_library(basic
-            SHARED
-            nn_sample.cpp
-            simple_model.cpp)
+    SHARED
+    nn_sample.cpp
+    simple_model.cpp
+)
 
 target_link_libraries(basic
-
-                      # Link with libneuralnetworks.so for NN API
-                      neuralnetworks
-                      android
-                      log)
+    # Link with libneuralnetworks.so for NN API
+    neuralnetworks
+    android
+    log
+)

--- a/nn-samples/sequence/src/main/cpp/CMakeLists.txt
+++ b/nn-samples/sequence/src/main/cpp/CMakeLists.txt
@@ -1,13 +1,15 @@
 cmake_minimum_required(VERSION 3.22.1)
+project(NnSamplesSequence LANGUAGES CXX)
 
 add_library(sequence
-        SHARED
-        sequence.cpp
-        sequence_model.cpp)
+    SHARED
+    sequence.cpp
+    sequence_model.cpp
+)
 
 target_link_libraries(sequence
-
-        # Link with libneuralnetworks.so for NN API
-        neuralnetworks
-        android
-        log)
+    # Link with libneuralnetworks.so for NN API
+    neuralnetworks
+    android
+    log
+)

--- a/san-angeles/app/src/main/cpp/CMakeLists.txt
+++ b/san-angeles/app/src/main/cpp/CMakeLists.txt
@@ -1,17 +1,20 @@
 cmake_minimum_required(VERSION 3.22.1)
+project(SanAngeles LANGUAGES C)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -Wall -Werror")
 add_definitions("-DANDROID_NDK -DDISABLE_IMPORTGL")
 
 add_library(sanangeles SHARED
-            app-android.c
-            demo.c
-            importgl.c)
+    app-android.c
+    demo.c
+    importgl.c
+)
 
 # Include libraries needed for sanangeles lib
 target_link_libraries(sanangeles
-                      android
-                      dl
-                      GLESv1_CM
-                      log
-                      m)
+    android
+    dl
+    GLESv1_CM
+    log
+    m
+)

--- a/sensor-graph/accelerometer/src/main/cpp/CMakeLists.txt
+++ b/sensor-graph/accelerometer/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.22.1)
+project(SensorGraph LANGUAGES CXX)
 
 # TODO: Remove -Wno-unused-variable
 # That warning is ignore for now because those are release config only issues
@@ -6,11 +7,11 @@ cmake_minimum_required(VERSION 3.22.1)
 # importing absl or libbase first.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-unused-variable")
 
-add_library(accelerometergraph SHARED
-            sensorgraph.cpp)
+add_library(accelerometergraph SHARED sensorgraph.cpp)
 
 # Include libraries needed for accelerometergraph lib
 target_link_libraries(accelerometergraph
-                      android
-                      GLESv2
-                      log)
+    android
+    GLESv2
+    log
+)


### PR DESCRIPTION
CMake really wants us to include this for some reason. I'm not sure why, but it's easy enough to shut up.

Some reformatting included because I can't be bothered to turn off the IDE's auto-formatter depending on whether I'm in a sample that's already been cleaned up or not.