### PR TITLE
Increase warning level for audio-echo.

### DIFF
--- a/audio-echo/app/src/main/cpp/CMakeLists.txt
+++ b/audio-echo/app/src/main/cpp/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(echo LANGUAGES C CXX)
 
+add_compile_options(-Wall -Wextra -Werror)
+
 add_library(echo
     SHARED
     audio_main.cpp
@@ -17,12 +19,6 @@ target_link_libraries(echo
     android
     log
     atomic)
-
-target_compile_options(echo
-    PRIVATE
-    -Wall
-    -Werror
-)
 
 if (ANDROID_ABI STREQUAL riscv64)
     # This sample uses OpenSLES, which was deprecated in API 26. Our

--- a/audio-echo/app/src/main/cpp/audio_effect.cpp
+++ b/audio-echo/app/src/main/cpp/audio_effect.cpp
@@ -130,7 +130,7 @@ float AudioDelay::getDecayWeight(void) const { return decayWeight_; }
  * @param channelCount for liveAudio, must be 2 for stereo
  * @param numFrames is length of liveAudio in Frames ( not in byte )
  */
-void AudioDelay::process(int16_t* liveAudio, int32_t numFrames) {
+void AudioDelay::process(int16_t* liveAudio, uint32_t numFrames) {
   if (feedbackFactor_ == 0 || bufSize_ < numFrames) {
     return;
   }
@@ -144,7 +144,7 @@ void AudioDelay::process(int16_t* liveAudio, int32_t numFrames) {
   }
 
   // process every sample
-  int32_t sampleCount = channelCount_ * numFrames;
+  auto sampleCount = channelCount_ * numFrames;
   int16_t* samples = &static_cast<int16_t*>(buffer_)[curPos_ * channelCount_];
   for (size_t idx = 0; idx < sampleCount; idx++) {
 #if 1

--- a/audio-echo/app/src/main/cpp/audio_effect.h
+++ b/audio-echo/app/src/main/cpp/audio_effect.h
@@ -50,7 +50,7 @@ class AudioDelay : public AudioFormat {
   size_t getDelayTime(void) const;
   void setDecayWeight(float weight);
   float getDecayWeight(void) const;
-  void process(int16_t* liveAudio, int32_t numFrames);
+  void process(int16_t* liveAudio, uint32_t numFrames);
 
  private:
   size_t delayTime_ = 0;

--- a/audio-echo/app/src/main/cpp/audio_main.cpp
+++ b/audio-echo/app/src/main/cpp/audio_main.cpp
@@ -52,8 +52,8 @@ static EchoAudioEngine engine;
 bool EngineService(void* ctx, uint32_t msg, void* data);
 
 JNIEXPORT void JNICALL Java_com_google_sample_echo_MainActivity_createSLEngine(
-    JNIEnv* env, jclass type, jint sampleRate, jint framesPerBuf,
-    jlong delayInMs, jfloat decay) {
+    JNIEnv*, jclass, jint sampleRate, jint framesPerBuf, jlong delayInMs,
+    jfloat decay) {
   SLresult result;
   memset(&engine, 0, sizeof(engine));
 
@@ -103,7 +103,7 @@ JNIEXPORT void JNICALL Java_com_google_sample_echo_MainActivity_createSLEngine(
 }
 
 JNIEXPORT jboolean JNICALL
-Java_com_google_sample_echo_MainActivity_configureEcho(JNIEnv* env, jclass type,
+Java_com_google_sample_echo_MainActivity_configureEcho(JNIEnv*, jclass,
                                                        jint delayInMs,
                                                        jfloat decay) {
   engine.echoDelay_ = delayInMs;
@@ -116,7 +116,7 @@ Java_com_google_sample_echo_MainActivity_configureEcho(JNIEnv* env, jclass type,
 
 JNIEXPORT jboolean JNICALL
 Java_com_google_sample_echo_MainActivity_createSLBufferQueueAudioPlayer(
-    JNIEnv* env, jclass type) {
+    JNIEnv*, jclass) {
   SampleFormat sampleFormat;
   memset(&sampleFormat, 0, sizeof(sampleFormat));
   sampleFormat.pcmFormat_ = (uint16_t)engine.bitsPerSample_;
@@ -138,7 +138,7 @@ Java_com_google_sample_echo_MainActivity_createSLBufferQueueAudioPlayer(
 
 JNIEXPORT void JNICALL
 Java_com_google_sample_echo_MainActivity_deleteSLBufferQueueAudioPlayer(
-    JNIEnv* env, jclass type) {
+    JNIEnv*, jclass) {
   if (engine.player_) {
     delete engine.player_;
     engine.player_ = nullptr;
@@ -146,8 +146,7 @@ Java_com_google_sample_echo_MainActivity_deleteSLBufferQueueAudioPlayer(
 }
 
 JNIEXPORT jboolean JNICALL
-Java_com_google_sample_echo_MainActivity_createAudioRecorder(JNIEnv* env,
-                                                             jclass type) {
+Java_com_google_sample_echo_MainActivity_createAudioRecorder(JNIEnv*, jclass) {
   SampleFormat sampleFormat;
   memset(&sampleFormat, 0, sizeof(sampleFormat));
   sampleFormat.pcmFormat_ = static_cast<uint16_t>(engine.bitsPerSample_);
@@ -166,15 +165,14 @@ Java_com_google_sample_echo_MainActivity_createAudioRecorder(JNIEnv* env,
 }
 
 JNIEXPORT void JNICALL
-Java_com_google_sample_echo_MainActivity_deleteAudioRecorder(JNIEnv* env,
-                                                             jclass type) {
+Java_com_google_sample_echo_MainActivity_deleteAudioRecorder(JNIEnv*, jclass) {
   if (engine.recorder_) delete engine.recorder_;
 
   engine.recorder_ = nullptr;
 }
 
 JNIEXPORT void JNICALL
-Java_com_google_sample_echo_MainActivity_startPlay(JNIEnv* env, jclass type) {
+Java_com_google_sample_echo_MainActivity_startPlay(JNIEnv*, jclass) {
   engine.frameCount_ = 0;
   /*
    * start player: make it into waitForData state
@@ -187,7 +185,7 @@ Java_com_google_sample_echo_MainActivity_startPlay(JNIEnv* env, jclass type) {
 }
 
 JNIEXPORT void JNICALL
-Java_com_google_sample_echo_MainActivity_stopPlay(JNIEnv* env, jclass type) {
+Java_com_google_sample_echo_MainActivity_stopPlay(JNIEnv*, jclass) {
   engine.recorder_->Stop();
   engine.player_->Stop();
 
@@ -197,8 +195,8 @@ Java_com_google_sample_echo_MainActivity_stopPlay(JNIEnv* env, jclass type) {
   engine.player_ = NULL;
 }
 
-JNIEXPORT void JNICALL Java_com_google_sample_echo_MainActivity_deleteSLEngine(
-    JNIEnv* env, jclass type) {
+JNIEXPORT void JNICALL
+Java_com_google_sample_echo_MainActivity_deleteSLEngine(JNIEnv*, jclass) {
   delete engine.recBufQueue_;
   delete engine.freeBufQueue_;
   releaseSampleBufs(engine.bufs_, engine.bufCount_);
@@ -236,7 +234,7 @@ uint32_t dbgEngineGetBufCount(void) {
 /*
  * simple message passing for player/recorder to communicate with engine
  */
-bool EngineService(void* ctx, uint32_t msg, void* data) {
+bool EngineService([[maybe_unused]] void* ctx, uint32_t msg, void* data) {
   assert(ctx == &engine);
   switch (msg) {
     case ENGINE_SERVICE_MSG_RETRIEVE_DUMP_BUFS: {

--- a/audio-echo/app/src/main/cpp/buf_manager.h
+++ b/audio-echo/app/src/main/cpp/buf_manager.h
@@ -50,39 +50,6 @@ class ProducerConsumerQueue {
     });
   }
 
-  // get() is idempotent between calls to commit().
-  T* getWriteablePtr() {
-    T* result = nullptr;
-
-    bool check __attribute__((unused));  //= false;
-
-    check = push([&](T* head) -> bool {
-      result = head;
-      return false;  // don't increment
-    });
-
-    // if there's no space, result should not have been set, and vice versa
-    assert(check == (result != nullptr));
-
-    return result;
-  }
-
-  bool commitWriteablePtr(T* ptr) {
-    bool result = push([&](T* head) -> bool {
-      // this writer func does nothing, because we assume that the caller
-      // has already written to *ptr after acquiring it from a call to get().
-      // So just double-check that ptr is actually at the write head, and
-      // return true to indicate that it's safe to advance.
-
-      // if this isn't the same pointer we got from a call to get(), then
-      // something has gone terribly wrong. Either there was an intervening
-      // call to push() or commit(), or the pointer is spurious.
-      assert(ptr == head);
-      return true;
-    });
-    return result;
-  }
-
   // writer() can return false, which indicates that the caller
   // of push() changed its mind while writing (e.g. ran out of bytes)
   template <typename F>


### PR DESCRIPTION
Add -Wextra, use add_compile_options instead of target_compile_options so it affects the whole file (there's only one target here so it makes no difference, but it's safer for copying), and fix the issues:

1. A function that took an int32_t for comparison with other unsigned types, despite the only caller passing a uint32_t that was being narrowed anyway.
2. A bunch of unused arguments.
3. Removed some unused code that had warnings rather than fixing it.