### PR TITLE
Cleanups in native-audio.

### DIFF
--- a/native-audio/app/src/main/cpp/CMakeLists.txt
+++ b/native-audio/app/src/main/cpp/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(NativeAudio LANGUAGES CXX)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+include(AppLibrary)
 
-add_library(native-audio-jni SHARED
+add_app_library(native-audio-jni SHARED
     native-audio-jni.cpp
 )
 
@@ -13,3 +13,13 @@ target_link_libraries(native-audio-jni
     log
     OpenSLES
 )
+
+if(ANDROID_ABI STREQUAL riscv64)
+    # This sample uses OpenSLES, which was deprecated in API 26. Our
+    # minSdkVersion is 23, but we also build for riscv64, which isn't a
+    # supported ABI yet and so that configuration is built for the latest API
+    # level supported by the NDK.
+    #
+    # Longer term, this sample should migrate to Oboe.
+    target_compile_options(native-audio-jni PRIVATE -Wno-deprecated-declarations)
+endif()

--- a/native-audio/app/src/main/cpp/CMakeLists.txt
+++ b/native-audio/app/src/main/cpp/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.22.1)
-project(NativeAudio LANGUAGES C)
+project(NativeAudio LANGUAGES CXX)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
 add_library(native-audio-jni SHARED
-    native-audio-jni.c
+    native-audio-jni.cpp
 )
 
 # Include libraries needed for native-audio-jni lib

--- a/native-audio/app/src/main/cpp/native-audio-jni.cpp
+++ b/native-audio/app/src/main/cpp/native-audio-jni.cpp
@@ -195,9 +195,9 @@ short* createResampledBuf(uint32_t idx, uint32_t srcRate, unsigned* size) {
 }
 
 // this callback handler is called every time a buffer finishes playing
-void bqPlayerCallback(SLAndroidSimpleBufferQueueItf bq, void* context) {
+void bqPlayerCallback([[maybe_unused]] SLAndroidSimpleBufferQueueItf bq,
+                      void*) {
   assert(bq == bqPlayerBufferQueue);
-  assert(NULL == context);
   // for streaming playback, replace this test by logic to find and fill the
   // next buffer
   if (--nextCount > 0 && NULL != nextBuffer && 0 != nextSize) {
@@ -218,9 +218,9 @@ void bqPlayerCallback(SLAndroidSimpleBufferQueueItf bq, void* context) {
 }
 
 // this callback handler is called every time a buffer finishes recording
-void bqRecorderCallback(SLAndroidSimpleBufferQueueItf bq, void* context) {
+void bqRecorderCallback([[maybe_unused]] SLAndroidSimpleBufferQueueItf bq,
+                        void*) {
   assert(bq == recorderBufferQueue);
-  assert(NULL == context);
   // for streaming recording, here we would call Enqueue to give recorder the
   // next buffer to fill but instead, this is a one-time buffer so we stop
   // recording
@@ -235,8 +235,7 @@ void bqRecorderCallback(SLAndroidSimpleBufferQueueItf bq, void* context) {
 
 // create the engine and output mix objects
 extern "C" JNIEXPORT void JNICALL
-Java_com_example_nativeaudio_NativeAudio_createEngine(JNIEnv* env,
-                                                      jclass clazz) {
+Java_com_example_nativeaudio_NativeAudio_createEngine(JNIEnv*, jclass) {
   SLresult result;
 
   // create engine
@@ -289,7 +288,7 @@ Java_com_example_nativeaudio_NativeAudio_createEngine(JNIEnv* env,
 // create buffer queue audio player
 extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_createBufferQueueAudioPlayer(
-    JNIEnv* env, jclass clazz, jint sampleRate, jint bufSize) {
+    JNIEnv*, jclass, jint sampleRate, jint bufSize) {
   SLresult result;
   if (sampleRate >= 0 && bufSize >= 0) {
     bqPlayerSampleRate = sampleRate * 1000;
@@ -398,7 +397,7 @@ Java_com_example_nativeaudio_NativeAudio_createBufferQueueAudioPlayer(
 // create URI audio player
 extern "C" JNIEXPORT jboolean JNICALL
 Java_com_example_nativeaudio_NativeAudio_createUriAudioPlayer(JNIEnv* env,
-                                                              jclass clazz,
+                                                              jclass,
                                                               jstring uri) {
   SLresult result;
 
@@ -474,7 +473,7 @@ Java_com_example_nativeaudio_NativeAudio_createUriAudioPlayer(JNIEnv* env,
 // to PLAYING (true) or PAUSED (false)
 extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setPlayingUriAudioPlayer(
-    JNIEnv* env, jclass clazz, jboolean isPlaying) {
+    JNIEnv*, jclass, jboolean isPlaying) {
   SLresult result;
 
   // make sure the URI audio player was created
@@ -491,7 +490,7 @@ Java_com_example_nativeaudio_NativeAudio_setPlayingUriAudioPlayer(
 // set the whole file looping state for the URI audio player
 extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setLoopingUriAudioPlayer(
-    JNIEnv* env, jclass clazz, jboolean isLooping) {
+    JNIEnv*, jclass, jboolean isLooping) {
   SLresult result;
 
   // make sure the URI audio player was created
@@ -518,7 +517,7 @@ static SLMuteSoloItf getMuteSolo() {
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setChannelMuteUriAudioPlayer(
-    JNIEnv* env, jclass clazz, jint chan, jboolean mute) {
+    JNIEnv*, jclass, jint chan, jboolean mute) {
   SLresult result;
   SLMuteSoloItf muteSoloItf = getMuteSolo();
   if (NULL != muteSoloItf) {
@@ -530,7 +529,7 @@ Java_com_example_nativeaudio_NativeAudio_setChannelMuteUriAudioPlayer(
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setChannelSoloUriAudioPlayer(
-    JNIEnv* env, jclass clazz, jint chan, jboolean solo) {
+    JNIEnv*, jclass, jint chan, jboolean solo) {
   SLresult result;
   SLMuteSoloItf muteSoloItf = getMuteSolo();
   if (NULL != muteSoloItf) {
@@ -541,8 +540,8 @@ Java_com_example_nativeaudio_NativeAudio_setChannelSoloUriAudioPlayer(
 }
 
 extern "C" JNIEXPORT jint JNICALL
-Java_com_example_nativeaudio_NativeAudio_getNumChannelsUriAudioPlayer(
-    JNIEnv* env, jclass clazz) {
+Java_com_example_nativeaudio_NativeAudio_getNumChannelsUriAudioPlayer(JNIEnv*,
+                                                                      jclass) {
   SLuint8 numChannels;
   SLresult result;
   SLMuteSoloItf muteSoloItf = getMuteSolo();
@@ -573,7 +572,7 @@ static SLVolumeItf getVolume() {
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setVolumeUriAudioPlayer(
-    JNIEnv* env, jclass clazz, jint millibel) {
+    JNIEnv*, jclass, jint millibel) {
   SLresult result;
   SLVolumeItf volumeItf = getVolume();
   if (NULL != volumeItf) {
@@ -584,8 +583,7 @@ Java_com_example_nativeaudio_NativeAudio_setVolumeUriAudioPlayer(
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_example_nativeaudio_NativeAudio_setMuteUriAudioPlayer(JNIEnv* env,
-                                                               jclass clazz,
+Java_com_example_nativeaudio_NativeAudio_setMuteUriAudioPlayer(JNIEnv*, jclass,
                                                                jboolean mute) {
   SLresult result;
   SLVolumeItf volumeItf = getVolume();
@@ -598,7 +596,7 @@ Java_com_example_nativeaudio_NativeAudio_setMuteUriAudioPlayer(JNIEnv* env,
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_enableStereoPositionUriAudioPlayer(
-    JNIEnv* env, jclass clazz, jboolean enable) {
+    JNIEnv*, jclass, jboolean enable) {
   SLresult result;
   SLVolumeItf volumeItf = getVolume();
   if (NULL != volumeItf) {
@@ -610,7 +608,7 @@ Java_com_example_nativeaudio_NativeAudio_enableStereoPositionUriAudioPlayer(
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setStereoPositionUriAudioPlayer(
-    JNIEnv* env, jclass clazz, jint permille) {
+    JNIEnv*, jclass, jint permille) {
   SLresult result;
   SLVolumeItf volumeItf = getVolume();
   if (NULL != volumeItf) {
@@ -622,7 +620,7 @@ Java_com_example_nativeaudio_NativeAudio_setStereoPositionUriAudioPlayer(
 
 // enable reverb on the buffer queue player
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_example_nativeaudio_NativeAudio_enableReverb(JNIEnv* env, jclass clazz,
+Java_com_example_nativeaudio_NativeAudio_enableReverb(JNIEnv*, jclass,
                                                       jboolean enabled) {
   SLresult result;
 
@@ -652,8 +650,8 @@ Java_com_example_nativeaudio_NativeAudio_enableReverb(JNIEnv* env, jclass clazz,
 
 // select the desired clip and play count, and enqueue the first buffer if idle
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_example_nativeaudio_NativeAudio_selectClip(JNIEnv* env, jclass clazz,
-                                                    jint which, jint count) {
+Java_com_example_nativeaudio_NativeAudio_selectClip(JNIEnv*, jclass, jint which,
+                                                    jint count) {
   if (pthread_mutex_trylock(&audioEngineLock)) {
     // If we could not acquire audio engine lock, reject this request and client
     // should re-try
@@ -726,7 +724,7 @@ Java_com_example_nativeaudio_NativeAudio_selectClip(JNIEnv* env, jclass clazz,
 // create asset audio player
 extern "C" JNIEXPORT jboolean JNICALL
 Java_com_example_nativeaudio_NativeAudio_createAssetAudioPlayer(
-    JNIEnv* env, jclass clazz, jobject assetManager, jstring filename) {
+    JNIEnv* env, jclass, jobject assetManager, jstring filename) {
   SLresult result;
 
   // convert Java string to UTF-8
@@ -815,7 +813,7 @@ Java_com_example_nativeaudio_NativeAudio_createAssetAudioPlayer(
 // set the playing state for the asset audio player
 extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setPlayingAssetAudioPlayer(
-    JNIEnv* env, jclass clazz, jboolean isPlaying) {
+    JNIEnv*, jclass, jboolean isPlaying) {
   SLresult result;
 
   // make sure the asset audio player was created
@@ -833,8 +831,7 @@ Java_com_example_nativeaudio_NativeAudio_setPlayingAssetAudioPlayer(
 //    like to avoid excessive re-sampling while playing back from Hello &
 //    Android clip
 extern "C" JNIEXPORT jboolean JNICALL
-Java_com_example_nativeaudio_NativeAudio_createAudioRecorder(JNIEnv* env,
-                                                             jclass clazz) {
+Java_com_example_nativeaudio_NativeAudio_createAudioRecorder(JNIEnv*, jclass) {
   SLresult result;
 
   // configure audio source
@@ -895,8 +892,7 @@ Java_com_example_nativeaudio_NativeAudio_createAudioRecorder(JNIEnv* env,
 
 // set the recording state for the audio recorder
 extern "C" JNIEXPORT void JNICALL
-Java_com_example_nativeaudio_NativeAudio_startRecording(JNIEnv* env,
-                                                        jclass clazz) {
+Java_com_example_nativeaudio_NativeAudio_startRecording(JNIEnv*, jclass) {
   SLresult result;
 
   if (pthread_mutex_trylock(&audioEngineLock)) {
@@ -934,7 +930,7 @@ Java_com_example_nativeaudio_NativeAudio_startRecording(JNIEnv* env,
 
 // shut down the native audio system
 extern "C" JNIEXPORT void JNICALL
-Java_com_example_nativeaudio_NativeAudio_shutdown(JNIEnv* env, jclass clazz) {
+Java_com_example_nativeaudio_NativeAudio_shutdown(JNIEnv*, jclass) {
   // destroy buffer queue audio player object, and invalidate all associated
   // interfaces
   if (bqPlayerObject != NULL) {

--- a/native-audio/app/src/main/cpp/native-audio-jni.cpp
+++ b/native-audio/app/src/main/cpp/native-audio-jni.cpp
@@ -234,8 +234,9 @@ void bqRecorderCallback(SLAndroidSimpleBufferQueueItf bq, void* context) {
 }
 
 // create the engine and output mix objects
-JNIEXPORT void JNICALL Java_com_example_nativeaudio_NativeAudio_createEngine(
-    JNIEnv* env, jclass clazz) {
+extern "C" JNIEXPORT void JNICALL
+Java_com_example_nativeaudio_NativeAudio_createEngine(JNIEnv* env,
+                                                      jclass clazz) {
   SLresult result;
 
   // create engine
@@ -286,7 +287,7 @@ JNIEXPORT void JNICALL Java_com_example_nativeaudio_NativeAudio_createEngine(
 }
 
 // create buffer queue audio player
-JNIEXPORT void JNICALL
+extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_createBufferQueueAudioPlayer(
     JNIEnv* env, jclass clazz, jint sampleRate, jint bufSize) {
   SLresult result;
@@ -395,14 +396,14 @@ Java_com_example_nativeaudio_NativeAudio_createBufferQueueAudioPlayer(
 }
 
 // create URI audio player
-JNIEXPORT jboolean JNICALL
+extern "C" JNIEXPORT jboolean JNICALL
 Java_com_example_nativeaudio_NativeAudio_createUriAudioPlayer(JNIEnv* env,
                                                               jclass clazz,
                                                               jstring uri) {
   SLresult result;
 
   // convert Java string to UTF-8
-  const char* utf8 = (*env)->GetStringUTFChars(env, uri, NULL);
+  const char* utf8 = env->GetStringUTFChars(uri, NULL);
   assert(NULL != utf8);
 
   // configure audio source
@@ -429,7 +430,7 @@ Java_com_example_nativeaudio_NativeAudio_createUriAudioPlayer(JNIEnv* env,
   (void)result;
 
   // release the Java string and UTF-8
-  (*env)->ReleaseStringUTFChars(env, uri, utf8);
+  env->ReleaseStringUTFChars(uri, utf8);
 
   // realize the player
   result = (*uriPlayerObject)->Realize(uriPlayerObject, SL_BOOLEAN_FALSE);
@@ -471,7 +472,7 @@ Java_com_example_nativeaudio_NativeAudio_createUriAudioPlayer(JNIEnv* env,
 
 // set the playing state for the URI audio player
 // to PLAYING (true) or PAUSED (false)
-JNIEXPORT void JNICALL
+extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setPlayingUriAudioPlayer(
     JNIEnv* env, jclass clazz, jboolean isPlaying) {
   SLresult result;
@@ -488,7 +489,7 @@ Java_com_example_nativeaudio_NativeAudio_setPlayingUriAudioPlayer(
 }
 
 // set the whole file looping state for the URI audio player
-JNIEXPORT void JNICALL
+extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setLoopingUriAudioPlayer(
     JNIEnv* env, jclass clazz, jboolean isLooping) {
   SLresult result;
@@ -515,7 +516,7 @@ static SLMuteSoloItf getMuteSolo() {
     return bqPlayerMuteSolo;
 }
 
-JNIEXPORT void JNICALL
+extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setChannelMuteUriAudioPlayer(
     JNIEnv* env, jclass clazz, jint chan, jboolean mute) {
   SLresult result;
@@ -527,7 +528,7 @@ Java_com_example_nativeaudio_NativeAudio_setChannelMuteUriAudioPlayer(
   }
 }
 
-JNIEXPORT void JNICALL
+extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setChannelSoloUriAudioPlayer(
     JNIEnv* env, jclass clazz, jint chan, jboolean solo) {
   SLresult result;
@@ -539,7 +540,7 @@ Java_com_example_nativeaudio_NativeAudio_setChannelSoloUriAudioPlayer(
   }
 }
 
-JNIEXPORT jint JNICALL
+extern "C" JNIEXPORT jint JNICALL
 Java_com_example_nativeaudio_NativeAudio_getNumChannelsUriAudioPlayer(
     JNIEnv* env, jclass clazz) {
   SLuint8 numChannels;
@@ -570,7 +571,7 @@ static SLVolumeItf getVolume() {
     return bqPlayerVolume;
 }
 
-JNIEXPORT void JNICALL
+extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setVolumeUriAudioPlayer(
     JNIEnv* env, jclass clazz, jint millibel) {
   SLresult result;
@@ -582,7 +583,7 @@ Java_com_example_nativeaudio_NativeAudio_setVolumeUriAudioPlayer(
   }
 }
 
-JNIEXPORT void JNICALL
+extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setMuteUriAudioPlayer(JNIEnv* env,
                                                                jclass clazz,
                                                                jboolean mute) {
@@ -595,7 +596,7 @@ Java_com_example_nativeaudio_NativeAudio_setMuteUriAudioPlayer(JNIEnv* env,
   }
 }
 
-JNIEXPORT void JNICALL
+extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_enableStereoPositionUriAudioPlayer(
     JNIEnv* env, jclass clazz, jboolean enable) {
   SLresult result;
@@ -607,7 +608,7 @@ Java_com_example_nativeaudio_NativeAudio_enableStereoPositionUriAudioPlayer(
   }
 }
 
-JNIEXPORT void JNICALL
+extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setStereoPositionUriAudioPlayer(
     JNIEnv* env, jclass clazz, jint permille) {
   SLresult result;
@@ -620,7 +621,7 @@ Java_com_example_nativeaudio_NativeAudio_setStereoPositionUriAudioPlayer(
 }
 
 // enable reverb on the buffer queue player
-JNIEXPORT jboolean JNICALL
+extern "C" JNIEXPORT jboolean JNICALL
 Java_com_example_nativeaudio_NativeAudio_enableReverb(JNIEnv* env, jclass clazz,
                                                       jboolean enabled) {
   SLresult result;
@@ -650,8 +651,9 @@ Java_com_example_nativeaudio_NativeAudio_enableReverb(JNIEnv* env, jclass clazz,
 }
 
 // select the desired clip and play count, and enqueue the first buffer if idle
-JNIEXPORT jboolean JNICALL Java_com_example_nativeaudio_NativeAudio_selectClip(
-    JNIEnv* env, jclass clazz, jint which, jint count) {
+extern "C" JNIEXPORT jboolean JNICALL
+Java_com_example_nativeaudio_NativeAudio_selectClip(JNIEnv* env, jclass clazz,
+                                                    jint which, jint count) {
   if (pthread_mutex_trylock(&audioEngineLock)) {
     // If we could not acquire audio engine lock, reject this request and client
     // should re-try
@@ -722,13 +724,13 @@ JNIEXPORT jboolean JNICALL Java_com_example_nativeaudio_NativeAudio_selectClip(
 }
 
 // create asset audio player
-JNIEXPORT jboolean JNICALL
+extern "C" JNIEXPORT jboolean JNICALL
 Java_com_example_nativeaudio_NativeAudio_createAssetAudioPlayer(
     JNIEnv* env, jclass clazz, jobject assetManager, jstring filename) {
   SLresult result;
 
   // convert Java string to UTF-8
-  const char* utf8 = (*env)->GetStringUTFChars(env, filename, NULL);
+  const char* utf8 = env->GetStringUTFChars(filename, NULL);
   assert(NULL != utf8);
 
   // use asset manager to open asset by filename
@@ -737,7 +739,7 @@ Java_com_example_nativeaudio_NativeAudio_createAssetAudioPlayer(
   AAsset* asset = AAssetManager_open(mgr, utf8, AASSET_MODE_UNKNOWN);
 
   // release the Java string and UTF-8
-  (*env)->ReleaseStringUTFChars(env, filename, utf8);
+  env->ReleaseStringUTFChars(filename, utf8);
 
   // the asset might not be found
   if (NULL == asset) {
@@ -811,7 +813,7 @@ Java_com_example_nativeaudio_NativeAudio_createAssetAudioPlayer(
 }
 
 // set the playing state for the asset audio player
-JNIEXPORT void JNICALL
+extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_setPlayingAssetAudioPlayer(
     JNIEnv* env, jclass clazz, jboolean isPlaying) {
   SLresult result;
@@ -830,7 +832,7 @@ Java_com_example_nativeaudio_NativeAudio_setPlayingAssetAudioPlayer(
 // create audio recorder: recorder is not in fast path
 //    like to avoid excessive re-sampling while playing back from Hello &
 //    Android clip
-JNIEXPORT jboolean JNICALL
+extern "C" JNIEXPORT jboolean JNICALL
 Java_com_example_nativeaudio_NativeAudio_createAudioRecorder(JNIEnv* env,
                                                              jclass clazz) {
   SLresult result;
@@ -892,8 +894,9 @@ Java_com_example_nativeaudio_NativeAudio_createAudioRecorder(JNIEnv* env,
 }
 
 // set the recording state for the audio recorder
-JNIEXPORT void JNICALL Java_com_example_nativeaudio_NativeAudio_startRecording(
-    JNIEnv* env, jclass clazz) {
+extern "C" JNIEXPORT void JNICALL
+Java_com_example_nativeaudio_NativeAudio_startRecording(JNIEnv* env,
+                                                        jclass clazz) {
   SLresult result;
 
   if (pthread_mutex_trylock(&audioEngineLock)) {
@@ -930,7 +933,7 @@ JNIEXPORT void JNICALL Java_com_example_nativeaudio_NativeAudio_startRecording(
 }
 
 // shut down the native audio system
-JNIEXPORT void JNICALL
+extern "C" JNIEXPORT void JNICALL
 Java_com_example_nativeaudio_NativeAudio_shutdown(JNIEnv* env, jclass clazz) {
   // destroy buffer queue audio player object, and invalidate all associated
   // interfaces


### PR DESCRIPTION
I'd originally thought I'd just end up deleting this sample since it uses the deprecated OpenSLES, but this sample has more features than hello-oboe does so I'll probably migrate it to Oboe later and delete hello-oboe instead.

For now, I've made the following cleanups:

1. Migrate to C++
2. Migrate to `add_app_library()` to increase the warning level