### PR TITLE
Add missing project to native-codec.

### DIFF
--- a/native-codec/app/src/main/cpp/CMakeLists.txt
+++ b/native-codec/app/src/main/cpp/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.22.1)
+project(NativeCodec LANGUAGES CXX)
 
 include(AppLibrary)
 


### PR DESCRIPTION
I'd missed this one somehow when I fixed all the others. Add it to shut up the warning.