### PR TITLE
Add READMEs to the deleted samples directories.

### DIFF
--- a/hello-neon/README.md
+++ b/hello-neon/README.md
@@ -1,0 +1,6 @@
+# Sample removed
+
+This sample has been removed in favor of the new `vectorization` sample, which
+demonstrates more options for vectorization and includes a benchmark to
+highlight that performance decisions cannot be made correctly unless you measure
+them.

--- a/native-media/README.md
+++ b/native-media/README.md
@@ -1,0 +1,5 @@
+# Sample removed
+
+This sample has been removed because we no longer recommend using OpenMAX AL in
+new code. See the `native-codec` sample instead for an example of how to use the
+Android Media APIs.

--- a/nn-samples/README.md
+++ b/nn-samples/README.md
@@ -1,0 +1,7 @@
+# Sample removed
+
+This sample has been removed because the Android Neural Networks API has been
+deprecated. Apps should instead use TensorFlow Lite. For for information, see
+the [NNAPI Migration Guide].
+
+[NNAPI Migration Guide]: https://developer.android.com/ndk/guides/neuralnetworks/migration-guide


### PR DESCRIPTION
It's not perfect because any stale links people follow that link to anything but this README will still be a 404, but it's at least something people can find if they walk up the dead link to the top of the sample's directory.