### PR TITLE
Simplify native_app_glue uses.

### DIFF
--- a/camera/basic/src/main/cpp/CMakeLists.txt
+++ b/camera/basic/src/main/cpp/CMakeLists.txt
@@ -18,17 +18,10 @@ cmake_minimum_required(VERSION 3.22.1)
 project(CameraBasic LANGUAGES C CXX)
 
 include(AppLibrary)
+include(AndroidNdkModules)
 find_package(camera-utils REQUIRED CONFIG)
 
-include_directories(${ANDROID_NDK}/sources/android/native_app_glue)
-
-add_library(app_glue STATIC
-    ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
-
-# Export ANativeActivity_onCreate(),
-# Refer to: https://github.com/android-ndk/ndk/issues/381.
-set(CMAKE_SHARED_LINKER_FLAGS
-    "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate")
+android_ndk_import_module_native_app_glue()
 
 add_app_library(ndk_camera SHARED
     ${CMAKE_CURRENT_SOURCE_DIR}/android_main.cpp
@@ -39,12 +32,13 @@ add_app_library(ndk_camera SHARED
     ${CMAKE_CURRENT_SOURCE_DIR}/camera_ui.cpp
 )
 
-# add lib dependencies
 target_link_libraries(ndk_camera
+    PRIVATE
     camera-utils::camera-utils
     android
     log
     m
-    app_glue
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,native_app_glue>
     camera2ndk
-    mediandk)
+    mediandk
+)

--- a/endless-tunnel/app/src/main/cpp/CMakeLists.txt
+++ b/endless-tunnel/app/src/main/cpp/CMakeLists.txt
@@ -18,16 +18,9 @@ cmake_minimum_required(VERSION 3.22.1)
 project(EndlessTunnel LANGUAGES C CXX)
 
 include(AppLibrary)
+include(AndroidNdkModules)
 
-# build native_app_glue as a static lib
-add_library(native_app_glue STATIC
-    ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c
-)
-
-# Export ANativeActivity_onCreate(),
-# Refer to: https://github.com/android-ndk/ndk/issues/381.
-set(CMAKE_SHARED_LINKER_FLAGS
-    "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate")
+android_ndk_import_module_native_app_glue()
 
 # Set common compiler options
 add_definitions("-DGLM_FORCE_SIZE_T_LENGTH -DGLM_FORCE_RADIANS")
@@ -63,7 +56,7 @@ add_app_library(game SHARED
     welcome_scene.cpp
 )
 
-if (ANDROID_ABI STREQUAL riscv64)
+if(ANDROID_ABI STREQUAL riscv64)
     # This sample uses OpenSLES, which was deprecated in API 26. Our
     # minSdkVersion is 21, but we also build for riscv64, which isn't a
     # supported ABI yet and so that configuration is built for the latest API
@@ -71,18 +64,17 @@ if (ANDROID_ABI STREQUAL riscv64)
     #
     # Longer term, this sample should migrate to Oboe.
     target_compile_options(game PRIVATE -Wno-deprecated-declarations)
-endif ()
+endif()
 
 target_include_directories(game PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/data
-    ${ANDROID_NDK}/sources/android/native_app_glue
 )
 
 # add lib dependencies
 target_link_libraries(game
     android
-    native_app_glue
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,native_app_glue>
     atomic
     EGL
     GLESv2

--- a/native-activity/app/src/main/cpp/CMakeLists.txt
+++ b/native-activity/app/src/main/cpp/CMakeLists.txt
@@ -18,16 +18,11 @@ cmake_minimum_required(VERSION 4.1.0)
 project(NativeActivity LANGUAGES C CXX)
 
 include(AppLibrary)
+include(AndroidNdkModules)
 
-add_library(native_app_glue STATIC
-    ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c
-)
+android_ndk_import_module_native_app_glue()
 
 add_app_library(native-activity SHARED main.cpp)
-
-target_include_directories(native-activity PRIVATE
-    ${ANDROID_NDK}/sources/android/native_app_glue
-)
 
 target_link_libraries(native-activity
     android


### PR DESCRIPTION
These should all just move to GameActivity, but that's a slightly more
involved migration. This is an easy first step to clean up the existing
callers.
