### PR TITLE
Fix Windows CMake path handling.

### DIFF
--- a/build-logic/src/main/java/com/android/ndk/samples/buildlogic/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/src/main/java/com/android/ndk/samples/buildlogic/AndroidApplicationConventionPlugin.kt
@@ -5,6 +5,7 @@ import com.android.build.api.dsl.ApplicationExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import java.lang.System.getProperty
 
 class AndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -30,7 +31,14 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                     externalNativeBuild {
                         cmake {
                             arguments.add("-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON")
-                            arguments.add("-DCMAKE_MODULE_PATH=${rootDir.resolve("cmake")}")
+                            // Determine if the OS is Windows
+                            val isWindows = getProperty("os.name").lowercase().contains("win")
+                            val cmakeModulePath = if (isWindows) {
+                                rootDir.resolve("cmake").toString().replace('\\', '/')
+                            } else {
+                                rootDir.resolve("cmake").toString()
+                            }
+                            arguments.add("-DCMAKE_MODULE_PATH=$cmakeModulePath")
                         }
                     }
 

--- a/build-logic/src/main/java/com/android/ndk/samples/buildlogic/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/src/main/java/com/android/ndk/samples/buildlogic/AndroidLibraryConventionPlugin.kt
@@ -4,6 +4,7 @@ import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import java.lang.System.getProperty
 
 class AndroidLibraryConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -33,7 +34,14 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                     externalNativeBuild {
                         cmake {
                             arguments.add("-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON")
-                            arguments.add("-DCMAKE_MODULE_PATH=${rootDir.resolve("cmake")}")
+                            // Determine if the OS is Windows
+                            val isWindows = getProperty("os.name").lowercase().contains("win")
+                            val cmakeModulePath = if (isWindows) {
+                                rootDir.resolve("cmake").toString().replace('\\', '/')
+                            } else {
+                                rootDir.resolve("cmake").toString()
+                            }
+                            arguments.add("-DCMAKE_MODULE_PATH=$cmakeModulePath")
                         }
                     }
                     ndk {


### PR DESCRIPTION
The CMake module path was not being handled correctly on Windows because backslashes were not escaped. This change explicitly replaces backslashes with forward slashes for the `CMAKE_MODULE_PATH` argument when building on Windows.