### PR TITLE
Support camera callback parameter added in r30

### DIFF
--- a/camera/basic/src/main/cpp/camera_listeners.cpp
+++ b/camera/basic/src/main/cpp/camera_listeners.cpp
@@ -70,8 +70,8 @@ void OnDeviceErrorChanges(void* ctx, ACameraDevice* dev, int err) {
 }
 
 #if __NDK_MAJOR__ >= 30
-void OnClientSharedAccessPriorityChanged(void *,
-                                         ACameraDevice *, bool) {
+void OnClientSharedAccessPriorityChanged(void*,
+                                         ACameraDevice*, bool) {
     // TODO: Implement this.
 }
 #endif

--- a/camera/texture-view/src/main/cpp/camera_listeners.cpp
+++ b/camera/texture-view/src/main/cpp/camera_listeners.cpp
@@ -70,8 +70,8 @@ void OnDeviceErrorChanges(void* ctx, ACameraDevice* dev, int err) {
 }
 
 #if __NDK_MAJOR__ >= 30
-void OnClientSharedAccessPriorityChanged(void *,
-                                         ACameraDevice *, bool) {
+void OnClientSharedAccessPriorityChanged(void*,
+                                         ACameraDevice*, bool) {
     // TODO: Implement this.
 }
 #endif


### PR DESCRIPTION
Without this change, build fails with NDK r30 due to missing field in initialization of the `ACameraDevice_stateCallbacks` object.