### PR TITLE
Explicitly disable parallel Gradle build

### DIFF
--- a/teapots/choreographer-30fps/src/main/cpp/CMakeLists.txt
+++ b/teapots/choreographer-30fps/src/main/cpp/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(base CONFIG REQUIRED)
 get_filename_component(commonDir ${CMAKE_CURRENT_SOURCE_DIR}/../../../../common ABSOLUTE)
 get_filename_component(ndkHelperSrc ${commonDir}/ndk_helper ABSOLUTE)
 add_subdirectory(${ndkHelperSrc}
-    ${commonDir}/ndkHelperBin/${CMAKE_BUILD_TYPE}/${ANDROID_ABI})
+    ndkHelperBin/${CMAKE_BUILD_TYPE}/${ANDROID_ABI})
 
 # now build app's shared lib
 add_app_library(${PROJECT_NAME}

--- a/teapots/classic-teapot/src/main/cpp/CMakeLists.txt
+++ b/teapots/classic-teapot/src/main/cpp/CMakeLists.txt
@@ -23,7 +23,7 @@ include(AppLibrary)
 get_filename_component(commonDir ${CMAKE_CURRENT_SOURCE_DIR}/../../../../common ABSOLUTE)
 get_filename_component(ndkHelperSrc ${commonDir}/ndk_helper ABSOLUTE)
 add_subdirectory(${ndkHelperSrc}
-    ${commonDir}/ndkHelperBin/${CMAKE_BUILD_TYPE}/${ANDROID_ABI})
+    ndkHelperBin/${CMAKE_BUILD_TYPE}/${ANDROID_ABI})
 
 # now build app's shared lib
 add_app_library(${PROJECT_NAME}

--- a/teapots/image-decoder/src/main/cpp/CMakeLists.txt
+++ b/teapots/image-decoder/src/main/cpp/CMakeLists.txt
@@ -24,7 +24,7 @@ get_filename_component(commonDir ${CMAKE_CURRENT_SOURCE_DIR}/../../../../common 
 # build the ndk-helper library
 get_filename_component(ndkHelperSrc ${commonDir}/ndk_helper ABSOLUTE)
 add_subdirectory(${ndkHelperSrc}
-    ${commonDir}/ndkHelperBin/${CMAKE_BUILD_TYPE}/${ANDROID_ABI})
+    ndkHelperBin/${CMAKE_BUILD_TYPE}/${ANDROID_ABI})
 
 # now build app's shared lib
 add_app_library(${PROJECT_NAME}

--- a/teapots/more-teapots/src/main/cpp/CMakeLists.txt
+++ b/teapots/more-teapots/src/main/cpp/CMakeLists.txt
@@ -23,7 +23,7 @@ include(AppLibrary)
 get_filename_component(commonDir ${CMAKE_CURRENT_SOURCE_DIR}/../../../../common ABSOLUTE)
 get_filename_component(ndkHelperSrc ${commonDir}/ndk_helper ABSOLUTE)
 add_subdirectory(${ndkHelperSrc}
-    ${commonDir}/ndkHelperBin/${CMAKE_BUILD_TYPE}/${ANDROID_ABI})
+    ndkHelperBin/${CMAKE_BUILD_TYPE}/${ANDROID_ABI})
 
 
 # now build app's shared lib

--- a/teapots/textured-teapot/src/main/cpp/CMakeLists.txt
+++ b/teapots/textured-teapot/src/main/cpp/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 # build the ndk-helper library
 get_filename_component(ndkHelperSrc ${commonDir}/ndk_helper ABSOLUTE)
 add_subdirectory(${ndkHelperSrc}
-    ${commonDir}/ndkHelperBin/${CMAKE_BUILD_TYPE}/${ANDROID_ABI})
+    ndkHelperBin/${CMAKE_BUILD_TYPE}/${ANDROID_ABI})
 
 # now build app's shared lib
 add_app_library(${PROJECT_NAME}


### PR DESCRIPTION
When building the entire project with Gradle, if Gradle-level inter-project parallelism is enabled (either via the property org.gradle.parallel=true, or via Android Studio injected flags), then the build was failing, because these sub-projects under the teapots project all try to write their ndkHelper library outputs to the same path, causing a race condition.
