### PR TITLE
Fix orderfile demo to use ftemporal-profile

### DIFF
--- a/orderfile/README.md
+++ b/orderfile/README.md
@@ -43,7 +43,7 @@ adb pull /data/local/tmp/demo.profraw .
    find `liborderfiledemo.so` and run `nm`
 
 ```
-mv demo.orderfile orderfile/app/src/main/cpp
+mv demo.orderfile app/src/main/cpp
 nm -n liborderfiledemo.so
 ```
 

--- a/orderfile/README.md
+++ b/orderfile/README.md
@@ -20,29 +20,17 @@ cold-start.
    sure `set(GENERATE_PROFILES ON)` is not commented. You need to pass any
    optimization flag except `-O0`. The mapping file is not generated and the
    profile instrumentation does not work without an optimization flag.
-1. Run the app on Android Studio. You can either run it on a physical or virtual
+2. Run the app on Android Studio. You can either run it on a physical or virtual
    device. You will see "Hello World" on the screen.
-1. To pull the data from the device, you'll need to move it from an app-writable
-   directory to a shell readable directory for adb pull. We also need to
-   transfer the output into hexadecimal format.
+3. To pull the data from the device, you'll need to move it from an app-writable
+   directory to a shell readable directory for adb pull.
+4. Use `llvm-profdata` to merge all the raw files and create an orderfile.
 
 ```
-adb shell "run-as com.example.orderfiledemo sh -c 'cat /data/user/0/com.example.orderfiledemo/cache/demo.output.order' | cat > /data/local/tmp/demo.output.order"
-adb pull /data/local/tmp/demo.output.order .
-
-# Convert to hexdeciaml format on Linux, Mac, or ChromeOS
-hexdump -C demo.output.order > demo.prof
-
-# Convert to hexdecimal format on Windows
-certutil -f -encodeHex demo.output.order demo.prof
-```
-
-4. Once you get both mapping file and profile file, you can use
-   [this script](https://android.googlesource.com/toolchain/pgo-profiles/+/refs/heads/main/scripts/create_orderfile.py)
-   to create the order file:
-
-```
-python3 create_orderfile.py --profile-file demo.prof --mapping-file mapping.txt --output app/src/main/cpp/demo.orderfile
+adb shell "run-as com.example.orderfiledemo sh -c 'cat /data/user/0/com.example.orderfiledemo/cache/demo.profraw' | cat > /data/local/tmp/demo.profraw"
+adb pull /data/local/tmp/demo.profraw .
+<NDK_PATH>/toolchains/llvm/prebuilt/<ARCH>/bin/llvm-profdata merge -o demo.profdata demo.profraw
+<NDK_PATH>/toolchains/llvm/prebuilt/<ARCH>/llvm-profdata order demo.profdata -o demo.orderfile
 ```
 
 ## Load Steps
@@ -51,10 +39,11 @@ python3 create_orderfile.py --profile-file demo.prof --mapping-file mapping.txt 
    `set(USE_PROFILE "${CMAKE_SOURCE_DIR}/demo.orderfile")` and make sure
    `set(GENERATE_PROFILES ON)` is commented.
 
-1. If you want to validate the shared library's layout is different, you need to
+2. If you want to validate the shared library's layout is different, you need to
    find `liborderfiledemo.so` and run `nm`
 
 ```
+mv demo.orderfile orderfile/app/src/main/cpp
 nm -n liborderfiledemo.so
 ```
 

--- a/orderfile/README.md
+++ b/orderfile/README.md
@@ -29,8 +29,8 @@ cold-start.
 ```
 adb shell "run-as com.example.orderfiledemo sh -c 'cat /data/user/0/com.example.orderfiledemo/cache/demo.profraw' | cat > /data/local/tmp/demo.profraw"
 adb pull /data/local/tmp/demo.profraw .
-<NDK_PATH>/toolchains/llvm/prebuilt/<ARCH>/bin/llvm-profdata merge -o demo.profdata demo.profraw
-<NDK_PATH>/toolchains/llvm/prebuilt/<ARCH>/llvm-profdata order demo.profdata -o demo.orderfile
+<NDK_PATH>/toolchains/llvm/prebuilt/<ARCH>/bin/llvm-profdata merge demo.profraw -o demo.profdata 
+<NDK_PATH>/toolchains/llvm/prebuilt/<ARCH>/bin/llvm-profdata order demo.profdata -o demo.orderfile
 ```
 
 ## Load Steps

--- a/orderfile/app/src/main/cpp/CMakeLists.txt
+++ b/orderfile/app/src/main/cpp/CMakeLists.txt
@@ -20,7 +20,6 @@ if(GENERATE_PROFILES)
     # Generating profiles requires any optimization flag aside from -O0.
     target_compile_options(orderfiledemo PRIVATE -fprofile-generate -ftemporal-profile -O1)
     target_link_options(orderfiledemo PRIVATE -fprofile-generate -ftemporal-profile)
->>>>>>> 366f74e3 (Fix orderfile demo to use ftemporal-profile)
     target_compile_definitions(orderfiledemo PRIVATE GENERATE_PROFILES)
 elseif(USE_PROFILE)
     target_compile_options(orderfiledemo PRIVATE)

--- a/orderfile/app/src/main/cpp/CMakeLists.txt
+++ b/orderfile/app/src/main/cpp/CMakeLists.txt
@@ -10,20 +10,19 @@ find_package(base CONFIG REQUIRED)
 # If you want to use your generated order file to layout symbols, uncomment USE_PROFILE.
 
 
-set(GENERATE_PROFILES ON)
-#set(USE_PROFILE "${CMAKE_SOURCE_DIR}/demo.orderfile")
+#set(GENERATE_PROFILES ON)
+set(USE_PROFILE "${CMAKE_SOURCE_DIR}/demo.orderfile")
 
 add_app_library(orderfiledemo SHARED orderfile.cpp)
 target_link_libraries(orderfiledemo PRIVATE base::base log)
 
 if(GENERATE_PROFILES)
     # Generating profiles requires any optimization flag aside from -O0.
-    # The mapping file will not generate and the profile instrumentation does not work without an optimization flag.
-    # Temporarily pass "-Wno-deprecated" since the order-file flags will be updated in a future PR
-    target_compile_options(orderfiledemo PRIVATE -forder-file-instrumentation -O1 -mllvm -orderfile-write-mapping=mapping.txt -Wno-deprecated)
-    target_link_options(orderfiledemo PRIVATE -forder-file-instrumentation)
+    target_compile_options(orderfiledemo PRIVATE -fprofile-generate -ftemporal-profile -O1)
+    target_link_options(orderfiledemo PRIVATE -fprofile-generate -ftemporal-profile)
+>>>>>>> 366f74e3 (Fix orderfile demo to use ftemporal-profile)
     target_compile_definitions(orderfiledemo PRIVATE GENERATE_PROFILES)
 elseif(USE_PROFILE)
-    target_compile_options(orderfiledemo PRIVATE -Wl,--symbol-ordering-file=${USE_PROFILE} -Wl,--no-warn-symbol-ordering)
+    target_compile_options(orderfiledemo PRIVATE)
     target_link_options(orderfiledemo PRIVATE -Wl,--symbol-ordering-file=${USE_PROFILE} -Wl,--no-warn-symbol-ordering)
 endif()

--- a/orderfile/app/src/main/cpp/CMakeLists.txt
+++ b/orderfile/app/src/main/cpp/CMakeLists.txt
@@ -10,8 +10,8 @@ find_package(base CONFIG REQUIRED)
 # If you want to use your generated order file to layout symbols, uncomment USE_PROFILE.
 
 
-#set(GENERATE_PROFILES ON)
-set(USE_PROFILE "${CMAKE_SOURCE_DIR}/demo.orderfile")
+set(GENERATE_PROFILES ON)
+#set(USE_PROFILE "${CMAKE_SOURCE_DIR}/demo.orderfile")
 
 add_app_library(orderfiledemo SHARED orderfile.cpp)
 target_link_libraries(orderfiledemo PRIVATE base::base log)

--- a/orderfile/app/src/main/cpp/demo.orderfile
+++ b/orderfile/app/src/main/cpp/demo.orderfile
@@ -1,0 +1,7 @@
+# Ordered 4 functions
+# Warning: Mach-O may prefix symbols with "_" depending on the linkage and this output does not take that into account. Some post-processing may be required before passing to the linker via -order_file.
+JNI_OnLoad
+_Z11RunWorkloadP7_JNIEnvP8_jobjectP8_jstring
+_Z23DumpProfileDataIfNeededPKc
+# /Users/sharjeelkhan/Desktop/ndk-samples/orderfile/app/src/main/cpp/orderfile.cpp
+_ZL8snprintfPcU17pass_object_size1mPKcz

--- a/orderfile/app/src/main/cpp/demo.orderfile
+++ b/orderfile/app/src/main/cpp/demo.orderfile
@@ -3,5 +3,4 @@
 JNI_OnLoad
 _Z11RunWorkloadP7_JNIEnvP8_jobjectP8_jstring
 _Z23DumpProfileDataIfNeededPKc
-# /Users/sharjeelkhan/Desktop/ndk-samples/orderfile/app/src/main/cpp/orderfile.cpp
 _ZL8snprintfPcU17pass_object_size1mPKcz

--- a/orderfile/app/src/main/cpp/demo.orderfile
+++ b/orderfile/app/src/main/cpp/demo.orderfile
@@ -1,5 +1,4 @@
 # Ordered 4 functions
-# Warning: Mach-O may prefix symbols with "_" depending on the linkage and this output does not take that into account. Some post-processing may be required before passing to the linker via -order_file.
 JNI_OnLoad
 _Z11RunWorkloadP7_JNIEnvP8_jobjectP8_jstring
 _Z23DumpProfileDataIfNeededPKc

--- a/orderfile/app/src/main/cpp/orderfile.cpp
+++ b/orderfile/app/src/main/cpp/orderfile.cpp
@@ -11,13 +11,13 @@ const char kLogTag[] = "orderfiledemo";
 #ifdef GENERATE_PROFILES
 extern "C" int __llvm_profile_set_filename(const char*);
 extern "C" int __llvm_profile_initialize_file(void);
-extern "C" int __llvm_orderfile_dump(void);
+extern "C" int __llvm_profile_dump(void);
 #endif
 
 void DumpProfileDataIfNeeded(const char* temp_dir) {
 #ifdef GENERATE_PROFILES
   char profile_location[PATH_MAX] = {};
-  snprintf(profile_location, sizeof(profile_location), "%s/demo.output",
+  snprintf(profile_location, sizeof(profile_location), "%s/demo.profraw",
            temp_dir);
   if (__llvm_profile_set_filename(profile_location) == -1) {
     __android_log_print(ANDROID_LOG_ERROR, kLogTag,
@@ -33,14 +33,15 @@ void DumpProfileDataIfNeeded(const char* temp_dir) {
     return;
   }
 
-  if (__llvm_orderfile_dump() == -1) {
+  if (__llvm_profile_dump() == -1) {
     __android_log_print(ANDROID_LOG_ERROR, kLogTag,
-                        "__llvm_orderfile_dump() failed: %s", strerror(errno));
+                        "__llvm_profile_dump() failed: %s", strerror(errno));
     return;
   }
   __android_log_print(ANDROID_LOG_DEBUG, kLogTag, "Wrote profile data to %s",
                       profile_location);
 #else
+  (void)temp_dir; // To avoid unused-parameter warning
   __android_log_print(ANDROID_LOG_DEBUG, kLogTag,
                       "Did not write profile data because the app was not "
                       "built for profile generation");


### PR DESCRIPTION
The original orderfile flag (`-forder-file-instrumentation`) was deprecated in https://github.com/llvm/llvm-project/pull/130192 and they have moved to using `ftemporal-profile` now. I have updated the orderfile demo to work with `ftemporal-profile` and updated the README with the new steps.